### PR TITLE
Fix how the wallet network is handled

### DIFF
--- a/src/commands/balance.rs
+++ b/src/commands/balance.rs
@@ -3,20 +3,23 @@ use gumdrop::Options;
 
 use zcash_client_backend::data_api::WalletRead;
 use zcash_client_sqlite::WalletDb;
-use zcash_primitives::{consensus::Parameters, zip32::AccountId};
+use zcash_primitives::zip32::AccountId;
 
-use crate::{data::get_db_paths, error, ui::format_zec, MIN_CONFIRMATIONS};
+use crate::{
+    data::{get_db_paths, get_wallet_network},
+    error,
+    ui::format_zec,
+    MIN_CONFIRMATIONS,
+};
 
 // Options accepted for the `balance` command
 #[derive(Debug, Options)]
 pub(crate) struct Command {}
 
 impl Command {
-    pub(crate) fn run(
-        self,
-        params: impl Parameters + Copy + 'static,
-        wallet_dir: Option<String>,
-    ) -> Result<(), anyhow::Error> {
+    pub(crate) fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
+        let params = get_wallet_network(wallet_dir.as_ref())?;
+
         let account = AccountId::from(0);
         let (_, db_data) = get_db_paths(wallet_dir);
         let db_data = WalletDb::for_path(db_data, params)?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -10,7 +10,7 @@ use zcash_client_sqlite::{
     chain::init::init_blockmeta_db, wallet::init::init_wallet_db, FsBlockDb, WalletDb,
 };
 use zcash_primitives::{
-    consensus::Parameters,
+    consensus::{self, Parameters},
     zip32::AccountId,
     zip339::{Count, Mnemonic},
 };
@@ -18,7 +18,7 @@ use zcash_primitives::{
 use crate::{
     data::{get_db_paths, init_wallet_keys, Network},
     error,
-    remote::{connect_to_lightwalletd, Lightwalletd},
+    remote::connect_to_lightwalletd,
 };
 
 // Options accepted for the `init` command
@@ -38,12 +38,9 @@ pub(crate) struct Command {
 }
 
 impl Command {
-    pub(crate) async fn run(
-        self,
-        params: impl Parameters + Lightwalletd + 'static,
-        wallet_dir: Option<String>,
-    ) -> Result<(), anyhow::Error> {
+    pub(crate) async fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
         let opts = self;
+        let params = consensus::Network::from(opts.network);
 
         // Get the current chain height (for the wallet's birthday).
         let mut client = connect_to_lightwalletd(&params).await?;

--- a/src/commands/list_unspent.rs
+++ b/src/commands/list_unspent.rs
@@ -4,7 +4,6 @@ use gumdrop::Options;
 use zcash_client_backend::data_api::{SaplingInputSource, WalletRead};
 use zcash_client_sqlite::WalletDb;
 use zcash_primitives::{
-    consensus::Parameters,
     transaction::components::{
         amount::{Amount, MAX_MONEY},
         sapling::fees::InputView,
@@ -12,18 +11,20 @@ use zcash_primitives::{
     zip32::AccountId,
 };
 
-use crate::{data::get_db_paths, error, ui::format_zec};
+use crate::{
+    data::{get_db_paths, get_wallet_network},
+    error,
+    ui::format_zec,
+};
 
 // Options accepted for the `balance` command
 #[derive(Debug, Options)]
 pub(crate) struct Command {}
 
 impl Command {
-    pub(crate) fn run(
-        self,
-        params: impl Parameters + Copy + 'static,
-        wallet_dir: Option<String>,
-    ) -> Result<(), anyhow::Error> {
+    pub(crate) fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
+        let params = get_wallet_network(wallet_dir.as_ref())?;
+
         let account = AccountId::from(0);
         let (_, db_data) = get_db_paths(wallet_dir);
         let db_data = WalletDb::for_path(db_data, params)?;

--- a/src/commands/propose.rs
+++ b/src/commands/propose.rs
@@ -8,12 +8,14 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::WalletDb;
 use zcash_primitives::{
-    consensus::Parameters,
     transaction::{components::amount::NonNegativeAmount, fees::StandardFeeRule},
     zip32::AccountId,
 };
 
-use crate::{data::get_db_paths, error, MIN_CONFIRMATIONS};
+use crate::{
+    data::{get_db_paths, get_wallet_network},
+    error, MIN_CONFIRMATIONS,
+};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum FeeRule {
@@ -66,11 +68,9 @@ pub(crate) struct Command {
 }
 
 impl Command {
-    pub(crate) async fn run(
-        self,
-        params: impl Parameters + Copy + 'static,
-        wallet_dir: Option<String>,
-    ) -> Result<(), anyhow::Error> {
+    pub(crate) async fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
+        let params = get_wallet_network(wallet_dir.as_ref())?;
+
         let account = AccountId::from(0);
         let (_, db_data) = get_db_paths(wallet_dir.as_ref());
         let mut db_data = WalletDb::for_path(db_data, params)?;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -24,9 +24,9 @@ use zcash_primitives::{
 };
 
 use crate::{
-    data::{get_block_path, get_db_paths},
+    data::{get_block_path, get_db_paths, get_wallet_network},
     error,
-    remote::{connect_to_lightwalletd, Lightwalletd},
+    remote::connect_to_lightwalletd,
 };
 
 const BATCH_SIZE: u32 = 10_000;
@@ -36,11 +36,9 @@ const BATCH_SIZE: u32 = 10_000;
 pub(crate) struct Command {}
 
 impl Command {
-    pub(crate) async fn run(
-        self,
-        params: impl Parameters + Lightwalletd + Copy + Send + 'static,
-        wallet_dir: Option<String>,
-    ) -> Result<(), anyhow::Error> {
+    pub(crate) async fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
+        let params = get_wallet_network(wallet_dir.as_ref())?;
+
         let (fsblockdb_root, db_data) = get_db_paths(wallet_dir.as_ref());
         let fsblockdb_root = fsblockdb_root.as_path();
         let mut db_cache = FsBlockDb::for_path(fsblockdb_root).map_err(error::Error::from)?;

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -5,10 +5,9 @@ use zcash_client_sqlite::{
     wallet::init::{init_wallet_db, WalletMigrationError},
     FsBlockDb, WalletDb,
 };
-use zcash_primitives::consensus::Parameters;
 
 use crate::{
-    data::{get_db_paths, get_wallet_seed},
+    data::{get_db_paths, get_wallet_network, get_wallet_seed},
     error,
 };
 
@@ -17,11 +16,9 @@ use crate::{
 pub(crate) struct Command {}
 
 impl Command {
-    pub(crate) fn run(
-        self,
-        params: impl Parameters + 'static,
-        wallet_dir: Option<String>,
-    ) -> Result<(), anyhow::Error> {
+    pub(crate) fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
+        let params = get_wallet_network(wallet_dir.as_ref())?;
+
         let (fsblockdb_root, db_data) = get_db_paths(wallet_dir.as_ref());
         let mut db_cache = FsBlockDb::for_path(fsblockdb_root).map_err(error::Error::from)?;
         let mut db_data = WalletDb::for_path(db_data, params)?;

--- a/src/data.rs
+++ b/src/data.rs
@@ -105,6 +105,10 @@ pub(crate) struct WalletKeys {
 }
 
 impl WalletKeys {
+    pub(crate) fn network(&self) -> consensus::Network {
+        self.network
+    }
+
     pub(crate) fn seed(&self) -> &SecretVec<u8> {
         &self.seed
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use std::env;
 use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use data::get_wallet_network;
 use gumdrop::Options;
 
 mod commands;
@@ -80,19 +79,17 @@ fn main() -> Result<(), anyhow::Error> {
         })
         .build()?;
 
-    let params = get_wallet_network(opts.wallet_dir.as_ref())?;
-
     runtime.block_on(async {
         match opts.command {
-            Some(Command::Init(command)) => command.run(params, opts.wallet_dir).await,
-            Some(Command::Reset(command)) => command.run(params, opts.wallet_dir).await,
-            Some(Command::Upgrade(command)) => command.run(params, opts.wallet_dir),
-            Some(Command::Sync(command)) => command.run(params, opts.wallet_dir).await,
-            Some(Command::Balance(command)) => command.run(params, opts.wallet_dir),
+            Some(Command::Init(command)) => command.run(opts.wallet_dir).await,
+            Some(Command::Reset(command)) => command.run(opts.wallet_dir).await,
+            Some(Command::Upgrade(command)) => command.run(opts.wallet_dir),
+            Some(Command::Sync(command)) => command.run(opts.wallet_dir).await,
+            Some(Command::Balance(command)) => command.run(opts.wallet_dir),
             Some(Command::ListTx(command)) => command.run(opts.wallet_dir),
-            Some(Command::ListUnspent(command)) => command.run(params, opts.wallet_dir),
-            Some(Command::Propose(command)) => command.run(params, opts.wallet_dir).await,
-            Some(Command::Send(command)) => command.run(params, opts.wallet_dir).await,
+            Some(Command::ListUnspent(command)) => command.run(opts.wallet_dir),
+            Some(Command::Propose(command)) => command.run(opts.wallet_dir).await,
+            Some(Command::Send(command)) => command.run(opts.wallet_dir).await,
             _ => Ok(()),
         }
     })


### PR DESCRIPTION
Now that the wallet network is stored in `keys.txt`, it is invalid to pass around network parameters alongside the wallet directory. They are now parsed at the place where the wallet directory is used (often at the same time as parsing the rest of `keys.txt`), and then passed around with other variables derived from it.

This also fixes a bug with the `init` command, where a new wallet could not be created unless an existing wallet at that path existed (to parse the network parameters from), but if that path existed then `init` (correctly) refused to overwrite it. The network parameters for this command are now correctly constructed from the config option.