### PR TITLE
sync: Send initial wallet summary to TUI after chain tip update

### DIFF
--- a/src/commands/sync/defrag.rs
+++ b/src/commands/sync/defrag.rs
@@ -108,17 +108,13 @@ pub(super) struct App {
 }
 
 impl App {
-    pub(super) fn new(
-        notify_shutdown: oneshot::Sender<()>,
-        wallet_birthday: BlockHeight,
-        wallet_summary: Option<WalletSummary<AccountId>>,
-    ) -> Self {
+    pub(super) fn new(notify_shutdown: oneshot::Sender<()>, wallet_birthday: BlockHeight) -> Self {
         let (action_tx, action_rx) = mpsc::unbounded_channel();
         Self {
             should_quit: false,
             notify_shutdown: Some(notify_shutdown),
             wallet_birthday,
-            wallet_summary,
+            wallet_summary: None,
             scan_ranges: BTreeMap::new(),
             fetching_set: RoaringBitmap::new(),
             fetched_set: RoaringBitmap::new(),


### PR DESCRIPTION
This ensures we don't sit at 100% scan progress while waiting for the first range to be scanned, then jump down to the actual scan progress.