### PR TITLE
Remove uses of `zcash_primitives` public reexports.

### DIFF
--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -7,17 +7,20 @@ use bech32::Bech32;
 use clap::Args;
 use lazy_static::lazy_static;
 use secrecy::Zeroize;
+
 use zcash_address::{
     unified::{self, Encoding},
     ZcashAddress,
 };
-use zcash_primitives::{block::BlockHeader, consensus::BranchId, transaction::Transaction};
+use zcash_primitives::{block::BlockHeader, transaction::Transaction};
 use zcash_proofs::{default_params_folder, load_parameters, ZcashParameters};
-use zcash_protocol::consensus::NetworkType;
+use zcash_protocol::{
+    consensus::{BranchId, NetworkType},
+    constants,
+};
 
 mod context;
 use context::{Context, ZUint256};
-use zcash_protocol::constants;
 
 mod address;
 mod block;

--- a/src/commands/inspect/address.rs
+++ b/src/commands/inspect/address.rs
@@ -1,7 +1,8 @@
 use zcash_address::{
     unified::{self, Container, Encoding},
-    ConversionError, Network, ToAddress, ZcashAddress,
+    ConversionError, ToAddress, ZcashAddress,
 };
+use zcash_protocol::consensus::NetworkType;
 
 #[allow(dead_code)]
 enum AddressKind {
@@ -14,14 +15,17 @@ enum AddressKind {
 }
 
 struct Address {
-    net: Network,
+    net: NetworkType,
     kind: AddressKind,
 }
 
 impl zcash_address::TryFromAddress for Address {
     type Error = ();
 
-    fn try_from_sprout(net: Network, data: [u8; 64]) -> Result<Self, ConversionError<Self::Error>> {
+    fn try_from_sprout(
+        net: NetworkType,
+        data: [u8; 64],
+    ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
             net,
             kind: AddressKind::Sprout(data),
@@ -29,7 +33,7 @@ impl zcash_address::TryFromAddress for Address {
     }
 
     fn try_from_sapling(
-        net: Network,
+        net: NetworkType,
         data: [u8; 43],
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
@@ -39,7 +43,7 @@ impl zcash_address::TryFromAddress for Address {
     }
 
     fn try_from_unified(
-        net: Network,
+        net: NetworkType,
         data: unified::Address,
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
@@ -49,7 +53,7 @@ impl zcash_address::TryFromAddress for Address {
     }
 
     fn try_from_transparent_p2pkh(
-        net: Network,
+        net: NetworkType,
         data: [u8; 20],
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
@@ -59,7 +63,7 @@ impl zcash_address::TryFromAddress for Address {
     }
 
     fn try_from_transparent_p2sh(
-        net: Network,
+        net: NetworkType,
         data: [u8; 20],
     ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
@@ -68,7 +72,10 @@ impl zcash_address::TryFromAddress for Address {
         })
     }
 
-    fn try_from_tex(net: Network, data: [u8; 20]) -> Result<Self, ConversionError<Self::Error>> {
+    fn try_from_tex(
+        net: NetworkType,
+        data: [u8; 20],
+    ) -> Result<Self, ConversionError<Self::Error>> {
         Ok(Address {
             net,
             kind: AddressKind::Tex(data),
@@ -87,9 +94,9 @@ pub(crate) fn inspect(addr: ZcashAddress) {
             eprintln!(
                 " - Network: {}",
                 match addr.net {
-                    Network::Main => "main",
-                    Network::Test => "testnet",
-                    Network::Regtest => "regtest",
+                    NetworkType::Main => "main",
+                    NetworkType::Test => "testnet",
+                    NetworkType::Regtest => "regtest",
                 }
             );
             eprintln!(

--- a/src/commands/inspect/block.rs
+++ b/src/commands/inspect/block.rs
@@ -2,17 +2,14 @@
 #![allow(clippy::assign_op_pattern)]
 #![allow(clippy::ptr_offset_with_cast)]
 
+use sha2::{Digest, Sha256};
 use std::cmp;
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, Read};
 
-use sha2::{Digest, Sha256};
 use zcash_encoding::Vector;
-use zcash_primitives::{
-    block::BlockHeader,
-    consensus::{BlockHeight, BranchId, Network, NetworkUpgrade, Parameters},
-    transaction::Transaction,
-};
+use zcash_primitives::{block::BlockHeader, transaction::Transaction};
+use zcash_protocol::consensus::{BlockHeight, BranchId, Network, NetworkUpgrade, Parameters};
 
 use super::{
     transaction::{extract_height_from_coinbase, is_coinbase},

--- a/src/commands/inspect/context.rs
+++ b/src/commands/inspect/context.rs
@@ -6,12 +6,13 @@ use serde::{
     de::{Unexpected, Visitor},
     Deserialize, Serialize, Serializer,
 };
-use zcash_primitives::{
-    consensus::Network,
-    legacy::Script,
-    transaction::components::{amount::NonNegativeAmount, transparent, TxOut},
-    zip32::AccountId,
+
+use ::transparent::{address::Script, bundle as transparent, bundle::TxOut};
+use zcash_protocol::{
+    consensus::{Network, NetworkType},
+    value::Zatoshis,
 };
+use zip32::AccountId;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct JsonNetwork(Network);
@@ -170,7 +171,7 @@ impl fmt::Display for ZUint256 {
 }
 
 #[derive(Clone, Debug)]
-struct ZOutputValue(NonNegativeAmount);
+struct ZOutputValue(Zatoshis);
 
 struct ZOutputValueVisitor;
 
@@ -185,7 +186,7 @@ impl Visitor<'_> for ZOutputValueVisitor {
     where
         E: serde::de::Error,
     {
-        NonNegativeAmount::from_u64(v)
+        Zatoshis::from_u64(v)
             .map(ZOutputValue)
             .map_err(|e| match e {
                 zcash_protocol::value::BalanceError::Overflow => serde::de::Error::invalid_type(
@@ -297,10 +298,10 @@ impl Context {
         self.network.map(|n| n.0)
     }
 
-    pub(crate) fn addr_network(&self) -> Option<zcash_address::Network> {
+    pub(crate) fn addr_network(&self) -> Option<NetworkType> {
         self.network().map(|params| match params {
-            Network::MainNetwork => zcash_address::Network::Main,
-            Network::TestNetwork => zcash_address::Network::Test,
+            Network::MainNetwork => NetworkType::Main,
+            Network::TestNetwork => NetworkType::Test,
         })
     }
 

--- a/src/commands/inspect/keys.rs
+++ b/src/commands/inspect/keys.rs
@@ -3,18 +3,16 @@ use std::iter;
 
 use bech32::{Bech32, Hrp};
 use secrecy::Zeroize;
+
+use ::transparent::{
+    address::TransparentAddress,
+    keys::{AccountPrivKey, IncomingViewingKey},
+};
 use zcash_address::{
     unified::{self, Encoding},
     ToAddress, ZcashAddress,
 };
 use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::{
-    legacy::{
-        keys::{AccountPrivKey, IncomingViewingKey},
-        TransparentAddress,
-    },
-    zip32,
-};
 use zcash_protocol::{
     consensus::{Network, NetworkConstants, NetworkType},
     local_consensus::LocalNetwork,

--- a/src/commands/inspect/transaction.rs
+++ b/src/commands/inspect/transaction.rs
@@ -8,10 +8,11 @@ use group::GroupEncoding;
 use sapling::{note_encryption::SaplingDomain, SaplingVerificationContext};
 use secp256k1::{Secp256k1, VerifyOnly};
 
+#[allow(deprecated)]
+use ::transparent::keys::pubkey_to_address;
 use ::transparent::{
     address::{Script, TransparentAddress},
     bundle as transparent,
-    keys::pubkey_to_address,
     sighash::{SighashType, TransparentAuthorizingContext},
 };
 use orchard::note_encryption::OrchardDomain;

--- a/src/commands/inspect/transaction.rs
+++ b/src/commands/inspect/transaction.rs
@@ -3,28 +3,34 @@ use std::{
     convert::{TryFrom, TryInto},
 };
 
-use ::transparent::sighash::SighashType;
 use bellman::groth16;
 use group::GroupEncoding;
-use orchard::note_encryption::OrchardDomain;
 use sapling::{note_encryption::SaplingDomain, SaplingVerificationContext};
 use secp256k1::{Secp256k1, VerifyOnly};
+
+use ::transparent::{
+    address::{Script, TransparentAddress},
+    bundle as transparent,
+    keys::pubkey_to_address,
+    sighash::{SighashType, TransparentAuthorizingContext},
+};
+use orchard::note_encryption::OrchardDomain;
 use zcash_address::{
     unified::{self, Encoding},
     ToAddress, ZcashAddress,
 };
 use zcash_note_encryption::try_output_recovery_with_ovk;
 #[allow(deprecated)]
-use zcash_primitives::{
+use zcash_primitives::transaction::{
+    components::sapling as sapling_serialization,
+    sighash::{signature_hash, SignableInput},
+    txid::TxIdDigester,
+    Authorization, Transaction, TransactionData, TxId, TxVersion,
+};
+use zcash_protocol::{
     consensus::BlockHeight,
-    legacy::{keys::pubkey_to_address, Script, TransparentAddress},
     memo::{Memo, MemoBytes},
-    transaction::{
-        components::{amount::NonNegativeAmount, sapling as sapling_serialization, transparent},
-        sighash::{signature_hash, SignableInput, TransparentAuthorizingContext},
-        txid::TxIdDigester,
-        Authorization, Transaction, TransactionData, TxId, TxVersion,
-    },
+    value::Zatoshis,
 };
 
 use super::{
@@ -106,7 +112,7 @@ impl transparent::Authorization for TransparentAuth {
 }
 
 impl TransparentAuthorizingContext for TransparentAuth {
-    fn input_amounts(&self) -> Vec<NonNegativeAmount> {
+    fn input_amounts(&self) -> Vec<Zatoshis> {
         self.all_prev_outputs
             .iter()
             .map(|prevout| prevout.value)

--- a/src/commands/pczt/create.rs
+++ b/src/commands/pczt/create.rs
@@ -5,6 +5,7 @@ use anyhow::anyhow;
 use clap::Args;
 use tokio::io::{stdout, AsyncWriteExt};
 use uuid::Uuid;
+
 use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
@@ -15,12 +16,12 @@ use zcash_client_backend::{
     },
     fees::{standard::MultiOutputChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule},
     wallet::OvkPolicy,
-    ShieldedProtocol,
 };
 use zcash_client_sqlite::WalletDb;
 use zcash_protocol::{
     memo::{Memo, MemoBytes},
     value::Zatoshis,
+    ShieldedProtocol,
 };
 use zip321::{Payment, TransactionRequest};
 

--- a/src/commands/pczt/inspect.rs
+++ b/src/commands/pczt/inspect.rs
@@ -3,8 +3,10 @@ use clap::Args;
 use pczt::{roles::verifier::Verifier, Pczt};
 use secrecy::ExposeSecret;
 use tokio::io::{stdin, AsyncReadExt};
+
+use ::transparent::sighash::SighashType;
 use zcash_primitives::transaction::{
-    sighash::{SighashType, SignableInput},
+    sighash::SignableInput,
     sighash_v5::v5_signature_hash,
     txid::{to_txid, TxIdDigester},
     TxVersion,

--- a/src/commands/pczt/qr.rs
+++ b/src/commands/pczt/qr.rs
@@ -254,11 +254,8 @@ impl<'b, C> minicbor::Decode<'b, C> for ZcashPczt {
         cbor_map(d, &mut result, |key, obj, d| {
             let key =
                 u8::try_from(key).map_err(|e| minicbor::decode::Error::message(e.to_string()))?;
-            match key {
-                DATA => {
-                    obj.data = d.bytes()?.to_vec();
-                }
-                _ => {}
+            if key == DATA {
+                obj.data = d.bytes()?.to_vec();
             }
             Ok(())
         })?;

--- a/src/commands/pczt/shield.rs
+++ b/src/commands/pczt/shield.rs
@@ -13,10 +13,9 @@ use zcash_client_backend::{
     },
     fees::{standard::MultiOutputChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule},
     wallet::OvkPolicy,
-    ShieldedProtocol,
 };
 use zcash_client_sqlite::WalletDb;
-use zcash_protocol::value::Zatoshis;
+use zcash_protocol::{value::Zatoshis, ShieldedProtocol};
 
 use crate::{commands::select_account, config::WalletConfig, data::get_db_paths, error};
 

--- a/src/commands/pczt/sign.rs
+++ b/src/commands/pczt/sign.rs
@@ -8,8 +8,9 @@ use pczt::{
 };
 use secrecy::ExposeSecret;
 use tokio::io::{stdin, stdout, AsyncReadExt, AsyncWriteExt};
+
+use ::transparent::keys::{NonHardenedChildIndex, TransparentKeyScope};
 use zcash_keys::keys::UnifiedSpendingKey;
-use zcash_primitives::legacy::keys::{NonHardenedChildIndex, TransparentKeyScope};
 use zcash_protocol::consensus::{NetworkConstants, Parameters};
 use zip32::fingerprint::SeedFingerprint;
 

--- a/src/commands/wallet/import_ufvk.rs
+++ b/src/commands/wallet/import_ufvk.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use clap::Args;
+
 use zcash_address::unified::{self, Encoding};
 use zcash_client_backend::{
     data_api::{AccountBirthday, AccountPurpose, WalletWrite, Zip32Derivation},
@@ -7,7 +8,7 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::WalletDb;
 use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::consensus;
+use zcash_protocol::consensus;
 use zip32::fingerprint::SeedFingerprint;
 
 use crate::{

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -9,8 +9,7 @@ use zcash_client_backend::{
     data_api::{AccountBirthday, WalletWrite},
     proto::service::{self, compact_tx_streamer_client::CompactTxStreamerClient},
 };
-use zcash_primitives::consensus::{self, Parameters};
-use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::consensus::{self, BlockHeight, Parameters};
 
 use crate::{
     config::WalletConfig,

--- a/src/commands/wallet/init_fvk.rs
+++ b/src/commands/wallet/init_fvk.rs
@@ -1,13 +1,13 @@
 use anyhow::anyhow;
 use clap::Args;
+
 use zcash_address::unified::{Encoding, Ufvk};
 use zcash_client_backend::{
     data_api::{AccountPurpose, WalletWrite, Zip32Derivation},
     proto::service,
 };
 use zcash_keys::{encoding::decode_extfvk_with_network, keys::UnifiedFullViewingKey};
-use zcash_primitives::consensus::NetworkType;
-use zcash_protocol::consensus;
+use zcash_protocol::consensus::{self, NetworkType};
 use zip32::fingerprint::SeedFingerprint;
 
 use crate::{

--- a/src/commands/wallet/list_tx.rs
+++ b/src/commands/wallet/list_tx.rs
@@ -2,16 +2,12 @@ use anyhow::anyhow;
 use clap::Args;
 use rusqlite::{named_params, Connection};
 use uuid::Uuid;
-use zcash_primitives::{
-    consensus::BlockHeight,
-    transaction::{
-        components::{amount::NonNegativeAmount, Amount},
-        TxId,
-    },
-};
+
 use zcash_protocol::{
+    consensus::BlockHeight,
     memo::{Memo, MemoBytes},
-    PoolType,
+    value::{ZatBalance, Zatoshis},
+    PoolType, TxId,
 };
 
 use crate::{data::get_db_paths, ui::format_zec};
@@ -132,7 +128,7 @@ struct WalletTxOutput {
     from_account: Option<Uuid>,
     to_account: Option<Uuid>,
     to_address: Option<String>,
-    value: NonNegativeAmount,
+    value: Zatoshis,
     is_change: bool,
     memo: Option<Memo>,
 }
@@ -165,7 +161,7 @@ impl WalletTxOutput {
             from_account,
             to_account,
             to_address,
-            value: NonNegativeAmount::from_nonnegative_i64(value)?,
+            value: Zatoshis::from_nonnegative_i64(value)?,
             is_change,
             memo: memo
                 .as_ref()
@@ -212,8 +208,8 @@ struct WalletTx {
     mined_height: Option<BlockHeight>,
     txid: TxId,
     expiry_height: Option<BlockHeight>,
-    account_balance_delta: Amount,
-    fee_paid: Option<NonNegativeAmount>,
+    account_balance_delta: ZatBalance,
+    fee_paid: Option<Zatoshis>,
     sent_note_count: usize,
     received_note_count: usize,
     memo_count: usize,
@@ -241,10 +237,10 @@ impl WalletTx {
             mined_height: mined_height.map(BlockHeight::from_u32),
             txid: TxId::from_bytes(txid.try_into().map_err(|_| anyhow!("Invalid TxId"))?),
             expiry_height: expiry_height.map(BlockHeight::from_u32),
-            account_balance_delta: Amount::from_i64(account_balance_delta)
+            account_balance_delta: ZatBalance::from_i64(account_balance_delta)
                 .map_err(|_| anyhow!("Amount out of range"))?,
             fee_paid: fee_paid
-                .map(|v| NonNegativeAmount::from_u64(v).map_err(|_| anyhow!("Fee out of range")))
+                .map(|v| Zatoshis::from_u64(v).map_err(|_| anyhow!("Fee out of range")))
                 .transpose()?,
             sent_note_count,
             received_note_count,

--- a/src/commands/wallet/list_unspent.rs
+++ b/src/commands/wallet/list_unspent.rs
@@ -1,12 +1,12 @@
 use anyhow::anyhow;
 use clap::Args;
 use uuid::Uuid;
-use zcash_client_backend::{
-    data_api::{Account as _, InputSource, WalletRead},
+use zcash_client_backend::data_api::{Account as _, InputSource, WalletRead};
+use zcash_client_sqlite::WalletDb;
+use zcash_protocol::{
+    value::{Zatoshis, MAX_MONEY},
     ShieldedProtocol,
 };
-use zcash_client_sqlite::WalletDb;
-use zcash_protocol::value::{Zatoshis, MAX_MONEY};
 
 use crate::{
     commands::select_account, config::get_wallet_network, data::get_db_paths, error, ui::format_zec,

--- a/src/commands/wallet/propose.rs
+++ b/src/commands/wallet/propose.rs
@@ -10,10 +10,9 @@ use zcash_client_backend::{
         Account as _,
     },
     fees::{zip317::MultiOutputChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule},
-    ShieldedProtocol,
 };
 use zcash_client_sqlite::WalletDb;
-use zcash_protocol::value::Zatoshis;
+use zcash_protocol::{value::Zatoshis, ShieldedProtocol};
 use zip321::{Payment, TransactionRequest};
 
 use crate::{

--- a/src/commands/wallet/send.rs
+++ b/src/commands/wallet/send.rs
@@ -5,6 +5,7 @@ use anyhow::anyhow;
 use clap::Args;
 use secrecy::ExposeSecret;
 use uuid::Uuid;
+
 use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
@@ -14,14 +15,13 @@ use zcash_client_backend::{
         Account, WalletRead,
     },
     fees::{standard::MultiOutputChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule},
-    keys::UnifiedSpendingKey,
     proto::service,
     wallet::OvkPolicy,
-    ShieldedProtocol,
 };
 use zcash_client_sqlite::WalletDb;
+use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_proofs::prover::LocalTxProver;
-use zcash_protocol::value::Zatoshis;
+use zcash_protocol::{value::Zatoshis, ShieldedProtocol};
 use zip321::{Payment, TransactionRequest};
 
 use crate::{

--- a/src/commands/wallet/shield.rs
+++ b/src/commands/wallet/shield.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use clap::Args;
 use secrecy::ExposeSecret;
 use uuid::Uuid;
+
 use zcash_client_backend::{
     data_api::{
         wallet::{
@@ -12,14 +13,13 @@ use zcash_client_backend::{
         Account, WalletRead,
     },
     fees::{standard::MultiOutputChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule},
-    keys::UnifiedSpendingKey,
     proto::service,
     wallet::OvkPolicy,
-    ShieldedProtocol,
 };
 use zcash_client_sqlite::WalletDb;
+use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_proofs::prover::LocalTxProver;
-use zcash_protocol::value::Zatoshis;
+use zcash_protocol::{value::Zatoshis, ShieldedProtocol};
 
 use crate::{
     commands::select_account,

--- a/src/commands/wallet/sync.rs
+++ b/src/commands/wallet/sync.rs
@@ -34,12 +34,13 @@ use crate::{
 
 #[cfg(feature = "transparent-inputs")]
 use {
-    zcash_client_backend::{encoding::AddressCodec, wallet::WalletTransparentOutput},
-    zcash_client_sqlite::AccountUuid,
-    zcash_primitives::{
-        legacy::Script,
-        transaction::components::transparent::{OutPoint, TxOut},
+    ::transparent::{
+        address::Script,
+        bundle::{OutPoint, TxOut},
     },
+    zcash_client_backend::wallet::WalletTransparentOutput,
+    zcash_client_sqlite::AccountUuid,
+    zcash_keys::encoding::AddressCodec,
     zcash_protocol::value::Zatoshis,
 };
 

--- a/src/commands/wallet/sync/defrag.rs
+++ b/src/commands/wallet/sync/defrag.rs
@@ -246,7 +246,7 @@ impl App {
             // Determine the density of blocks we will be rendering. Use ceiling division
             // to ensure we don't require more cells than we have (which would cause the
             // blocks around the chain tip to never be rendered).
-            let area = u32::from(defrag_area.area());
+            let area = defrag_area.area();
             let blocks_per_cell = (block_count + area - 1) / area;
             let blocks_per_row = blocks_per_cell * u32::from(defrag_area.width);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,8 +7,7 @@ use std::path::Path;
 use secrecy::{ExposeSecret, SecretVec, Zeroize};
 use serde::{Deserialize, Serialize};
 
-use zcash_primitives::consensus::{self, BlockHeight};
-use zcash_protocol::consensus::Parameters;
+use zcash_protocol::consensus::{self, BlockHeight, Parameters};
 
 use crate::{
     data::{Network, DEFAULT_WALLET_DIR},

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,8 +6,7 @@ use zcash_client_sqlite::{FsBlockDb, WalletDb};
 use tracing::error;
 
 use zcash_client_sqlite::chain::BlockMeta;
-use zcash_primitives::consensus;
-use zcash_protocol::consensus::Parameters;
+use zcash_protocol::consensus::{self, Parameters};
 
 use crate::error;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,13 @@
 use std::convert::Infallible;
 use std::fmt;
 
-use zcash_client_backend::{
-    data_api::{
-        error::Error as WalletError, wallet::input_selection::GreedyInputSelectorError,
-        BirthdayError,
-    },
-    keys::DerivationError,
+use zcash_client_backend::data_api::{
+    error::Error as WalletError, wallet::input_selection::GreedyInputSelectorError, BirthdayError,
 };
 use zcash_client_sqlite::{
     error::SqliteClientError, wallet::commitment_tree, FsBlockDbError, ReceivedNoteId,
 };
+use zcash_keys::keys::DerivationError;
 use zcash_primitives::transaction::fees::zip317;
 use zip321::Zip321Error;
 


### PR DESCRIPTION
This is a pure refactoring to regularize the use of `librustzcash` APIs and make it easier to find things.