### PR TITLE
devtools: Add block hash lookups

### DIFF
--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -147,7 +147,7 @@ async fn inspect_bytes(bytes: Vec<u8>, context: Option<Context>, lookup: bool) {
 }
 
 async fn inspect_possible_hash(bytes: [u8; 32], context: Option<Context>, lookup: bool) {
-    let maybe_mainnet_block_hash = bytes.iter().take(4).all(|c| c == &0);
+    let mut maybe_mainnet_block_hash = bytes.iter().take(4).all(|c| c == &0);
 
     if lookup {
         // Block hashes and txids are byte-reversed; we didn't do this when parsing the
@@ -159,6 +159,13 @@ async fn inspect_possible_hash(bytes: [u8; 32], context: Option<Context>, lookup
             match lookup::Lightwalletd::mainnet().await {
                 Err(e) => eprintln!("Error: Failed to connect to mainnet lightwalletd: {:?}", e),
                 Ok(mut mainnet) => {
+                    if let Some(block) = mainnet.lookup_block_hash(candidate).await {
+                        block::inspect_block_hash(&block, "main");
+                        return true;
+                    } else {
+                        maybe_mainnet_block_hash = false;
+                    }
+
                     if let Some((tx, mined_height)) = mainnet.lookup_txid(candidate).await {
                         transaction::inspect(tx, context, mined_height);
                         return true;
@@ -169,6 +176,11 @@ async fn inspect_possible_hash(bytes: [u8; 32], context: Option<Context>, lookup
             match lookup::Lightwalletd::testnet().await {
                 Err(e) => eprintln!("Error: Failed to connect to testnet lightwalletd: {:?}", e),
                 Ok(mut testnet) => {
+                    if let Some(block) = testnet.lookup_block_hash(candidate).await {
+                        block::inspect_block_hash(&block, "test");
+                        return true;
+                    }
+
                     if let Some((tx, mined_height)) = testnet.lookup_txid(candidate).await {
                         transaction::inspect(tx, context, mined_height);
                         return true;

--- a/src/commands/inspect/block.rs
+++ b/src/commands/inspect/block.rs
@@ -6,6 +6,7 @@ use sha2::{Digest, Sha256};
 use std::cmp;
 use std::convert::{TryFrom, TryInto};
 use std::io::{self, Read};
+use zcash_client_backend::proto::compact_formats::CompactBlock;
 
 use zcash_encoding::Vector;
 use zcash_primitives::{block::BlockHeader, transaction::Transaction};
@@ -277,6 +278,13 @@ fn inspect_header_inner(header: &BlockHeader, params: Option<Network>) {
     } else {
         eprintln!("🔎 To check contextual rules, add \"network\" to context (either \"main\" or \"test\")");
     }
+}
+
+/// Used when a block hash is resolved via lightwalletd.
+pub(crate) fn inspect_block_hash(block: &CompactBlock, network: &'static str) {
+    eprintln!("Zcash block hash");
+    eprintln!(" - Network: {}", network);
+    eprintln!(" - Height: {}", block.height());
 }
 
 pub(crate) fn inspect(block: &Block, context: Option<Context>) {

--- a/src/commands/inspect/lookup.rs
+++ b/src/commands/inspect/lookup.rs
@@ -1,6 +1,7 @@
 use tonic::transport::{Channel, ClientTlsConfig};
-use zcash_client_backend::proto::service::{
-    compact_tx_streamer_client::CompactTxStreamerClient, TxFilter,
+use zcash_client_backend::proto::{
+    compact_formats::CompactBlock,
+    service::{compact_tx_streamer_client::CompactTxStreamerClient, BlockId, TxFilter},
 };
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::consensus::{BlockHeight, BranchId, Network};
@@ -56,6 +57,18 @@ impl Lightwalletd {
             inner: connect(&TESTNET).await?,
             parameters: Network::TestNetwork,
         })
+    }
+
+    pub(crate) async fn lookup_block_hash(&mut self, candidate: [u8; 32]) -> Option<CompactBlock> {
+        let request = BlockId {
+            hash: candidate.into(),
+            ..Default::default()
+        };
+        self.inner
+            .get_block(request)
+            .await
+            .ok()
+            .map(|b| b.into_inner())
     }
 
     pub(crate) async fn lookup_txid(


### PR DESCRIPTION
Curently doesn't work because `lightwalletd` does not have support for looking up blocks by hash.