### PR TITLE
Add a `create-multisig-address` command similar to the RPC method in zcashd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7915,6 +7915,7 @@ dependencies = [
  "rand",
  "ratatui",
  "rayon",
+ "ripemd 0.1.3",
  "roaring",
  "rqrr",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 bip0039 = { version = "0.12", features = ["std", "all-languages"] }
-bip32 = { version = "=0.6.0-pre.1", default-features = false }
+bip32 = { version = "=0.6.0-pre.1", default-features = false, features = ["secp256k1-ffi"] }
 futures-util = "0.3"
 hex = "0.4"
 jubjub = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ jubjub = "0.10"
 nonempty = { version = "0.11", default-features = false }
 prost = "0.13"
 rayon = "1.7"
+ripemd = "0.1"
 rusqlite = { version = "0.32", features = ["time"] }
 schemerz = "0.2"
 secrecy = "0.8"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 use zcash_client_backend::data_api::WalletRead;
 use zcash_client_sqlite::AccountUuid;
 
+pub(crate) mod create_multisig_address;
 pub(crate) mod inspect;
 pub(crate) mod pczt;
 pub(crate) mod wallet;

--- a/src/commands/create_multisig_address.rs
+++ b/src/commands/create_multisig_address.rs
@@ -1,0 +1,111 @@
+//! Command for managing multisig addresses in Zcash Devtool.
+//!
+//! Accepts a threshold number of signatures to be required by the generated multisig address and a list
+//! of public keys in hex format, separated by commas, that should be able to participate in signing spends from the multi-sig
+//! address produced by this command.
+//!
+//! Generates a multi-sig P2SH address that can be used to send and receive funds, requiring the specified threshold number of
+//! signatures to authorize spending from the generated address.
+
+// TODO: Add a wallet subcommand that accepts known p2pkh addresses and which adds the generated multisig address to the wallet.
+
+use clap::Args;
+use secp256k1::PublicKey;
+use sha2::{Digest, Sha256};
+
+use ::transparent::address::Script;
+use transparent::address::TransparentAddress;
+use zcash_keys::encoding::AddressCodec;
+use zcash_protocol::consensus::Network;
+
+/// Maximum size of a script element in bytes
+// TODO: Move this constant to `zcash_transparent` if it's needed.
+const MAX_SCRIPT_ELEMENT_SIZE: usize = 520;
+
+/// Commands for managing multisig addresses.
+#[derive(Debug, Args)]
+pub(crate) struct Command {
+    /// Add a nrequired-to-sign transparent multisignature address to the wallet
+
+    /// A threshold `k` value indicating the number of signatures required to spend from the address
+    #[clap(short, long, required = true)]
+    threshold: u32,
+
+    /// A list of comma-separated hex-encoded public keys.
+    /// Must contain at least the threshold number of keys.
+    #[clap(short, long, required = true, value_delimiter = ',')]
+    pub_keys: Vec<PublicKey>,
+
+    /// The network to use for the multisig address.
+    #[clap(short, long, default_value = "test")]
+    #[arg(value_parser = crate::data::Network::parse)]
+    network: crate::data::Network,
+}
+
+impl Command {
+    pub(crate) fn run(self) -> anyhow::Result<()> {
+        let Self {
+            threshold,
+            pub_keys,
+            network,
+        } = self;
+
+        let (multisig_script, addr) = multisig_script(threshold, pub_keys)?;
+        let addr = addr.encode(&Network::from(network));
+        println!("Created multisig address: {addr}");
+        println!("Script: {multisig_script:?}");
+
+        Ok(())
+    }
+}
+
+fn multisig_script(
+    threshold: u32,
+    pub_keys: Vec<PublicKey>,
+) -> anyhow::Result<(Script, TransparentAddress)> {
+    validate_args(threshold, &pub_keys)?;
+
+    // TODO: Make `Opcode` public and use the enum variants instead of raw opcodes.
+    let multisig_redeem_script = Script(
+        std::iter::once(0x50 + threshold as u8) // Push the number of required signatures (OP_1 to OP_16)
+            .chain(pub_keys.iter().flat_map(|pk| {
+                let bytes = pk.serialize();
+                [&[bytes.len() as u8], bytes.as_slice()].concat()
+            })) // Push each public key
+            .chain([0x50 + pub_keys.len() as u8, 0xAE]) // Push the number of keys (OP_1 to OP_16) followed by OP_CHECKMULTISIG.
+            .collect(),
+    );
+
+    if multisig_redeem_script.0.len() > MAX_SCRIPT_ELEMENT_SIZE {
+        return Err(anyhow::anyhow!(
+            "the multisig script is too large, it must be less than {MAX_SCRIPT_ELEMENT_SIZE} bytes",
+        ));
+    }
+
+    let script_id = ripemd::Ripemd160::digest(Sha256::digest(&multisig_redeem_script.0));
+    let address = TransparentAddress::ScriptHash(script_id.into());
+
+    Ok((multisig_redeem_script, address))
+}
+
+fn validate_args(threshold: u32, pub_keys: &[PublicKey]) -> anyhow::Result<()> {
+    if threshold < 1 {
+        return Err(anyhow::anyhow!("a multisignature address must require at least one key to redeem, threshold must be at least 1"));
+    }
+
+    if pub_keys.len() < threshold as usize {
+        return Err(anyhow::anyhow!(
+            "not enough keys supplied, (got {} keys, but need at least {threshold} to redeem)",
+            pub_keys.len()
+        ));
+    }
+
+    // TODO: Find out if this is correct (in zcashd, the max script size is 520 bytes, but the max number of public keys is 16, 3 + 16*34 == 547 > 520).
+    if pub_keys.len() > 16 {
+        return Err(anyhow::anyhow!(
+            "number of addresses involved in the multisignature address creation > 16\nreduce the number"
+        ));
+    }
+
+    Ok(())
+}

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -3,6 +3,7 @@ use clap::Subcommand;
 pub(crate) mod balance;
 pub(crate) mod display_mnemonic;
 pub(crate) mod enhance;
+pub(crate) mod gen_account;
 pub(crate) mod gen_addr;
 pub(crate) mod import_ufvk;
 pub(crate) mod init;
@@ -47,6 +48,9 @@ pub(crate) enum Command {
 
     /// Get the balance in the wallet
     Balance(balance::Command),
+
+    /// Generate a new account in the wallet
+    GenerateAccount(gen_account::Command),
 
     /// List the accounts in the wallet
     ListAccounts(list_accounts::Command),

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -1,6 +1,7 @@
 use clap::Subcommand;
 
 pub(crate) mod balance;
+pub(crate) mod derive_path;
 pub(crate) mod display_mnemonic;
 pub(crate) mod enhance;
 pub(crate) mod gen_account;
@@ -60,6 +61,9 @@ pub(crate) enum Command {
 
     /// List the addresses for an account in the wallet
     ListAddresses(list_addresses::Command),
+
+    /// Derive key material at a particular path below the wallet seed
+    DerivePath(derive_path::Command),
 
     /// List the transactions in the wallet
     ListTx(list_tx::Command),

--- a/src/commands/wallet/derive_path.rs
+++ b/src/commands/wallet/derive_path.rs
@@ -1,0 +1,183 @@
+use anyhow::anyhow;
+use bip32::PublicKey;
+use clap::Args;
+use secrecy::ExposeSecret;
+use sha2::{Digest, Sha256};
+use zcash_address::{ToAddress, ZcashAddress};
+use zcash_protocol::{
+    consensus::{NetworkConstants, Parameters},
+    PoolType,
+};
+
+use crate::config::WalletConfig;
+
+// Options accepted for the `derive-path` command
+#[derive(Debug, Args)]
+pub(crate) struct Command {
+    /// age identity file to decrypt the mnemonic phrase with
+    #[arg(short, long)]
+    identity: String,
+
+    /// The pool to derive within.
+    #[arg(value_parser = parse_pool_type)]
+    pool: PoolType,
+
+    /// The ZIP 32 or BIP 44 path to derive.
+    path: String,
+}
+
+impl Command {
+    pub(crate) fn run(self, wallet_dir: Option<String>) -> anyhow::Result<()> {
+        let path = parse_path(&self.path)?;
+
+        let mut config = WalletConfig::read(wallet_dir.as_ref())?;
+        let params = config.network();
+
+        // Decrypt the mnemonic to access the seed.
+        let identities = age::IdentityFile::from_file(self.identity)?.into_identities()?;
+        let seed = config
+            .decrypt_seed(identities.iter().map(|i| i.as_ref() as _))?
+            .ok_or(anyhow!(
+                "Seed must be present to enable generating a new account"
+            ))?;
+
+        match self.pool {
+            PoolType::Transparent => {
+                let mut xprv =
+                    bip32::ExtendedPrivateKey::<secp256k1::SecretKey>::new(seed.expose_secret())
+                        .map_err(|e| anyhow!("{e}"))?;
+
+                for (index, hardened) in &path {
+                    let child_number =
+                        bip32::ChildNumber::new(*index, *hardened).map_err(|e| anyhow!("{e}"))?;
+                    xprv = xprv
+                        .derive_child(child_number)
+                        .map_err(|e| anyhow!("{e}"))?;
+                }
+
+                let xpub = xprv.public_key();
+
+                // Print out transparent information.
+                println!("Transparent derivation at {}:", self.path);
+                let show_address = match path.as_slice() {
+                    [(44, true), subpath @ ..] => {
+                        println!(" - BIP 44 derivation path");
+                        match subpath {
+                            [] => {
+                                println!("  ⚠️  Missing coin type");
+                                false
+                            }
+                            [_] => {
+                                println!("  ⚠️  Missing account");
+                                false
+                            }
+                            [(coin_type, coin_type_hardened), (account, account_hardened), subpath @ ..] =>
+                            {
+                                if !*coin_type_hardened {
+                                    println!("  ⚠️  Coin type is not hardened");
+                                }
+                                let network_match = *coin_type == params.coin_type();
+                                if !network_match {
+                                    println!(
+                                        "  ⚠️  Coin type ({}) does not match the wallet's network ({})",
+                                        coin_type,
+                                        params.coin_type(),
+                                    );
+                                }
+                                println!("   - Account: {account}");
+                                if !*account_hardened {
+                                    println!("  ⚠️  Account is not hardened");
+                                }
+                                match subpath {
+                                    [(kind, kind_hardened), (address_index, address_index_hardened)] =>
+                                    {
+                                        match kind {
+                                            0 => println!("   - External chain"),
+                                            1 => println!("   - Internal chain (change addresses)"),
+                                            2 => println!(
+                                                "   - Ephemeral chain (TEX address payments)"
+                                            ),
+                                            _ => println!("  ⚠️  Unknown address kind"),
+                                        }
+                                        if *kind_hardened {
+                                            println!("  ⚠️  Address kind is hardened");
+                                        }
+                                        println!("   - Address index: {address_index}");
+                                        if *address_index_hardened {
+                                            println!("  ⚠️  Address index is hardened");
+                                        }
+                                        // Only encode as an address if the network
+                                        // matches the wallet.
+                                        network_match
+                                    }
+                                    _ => false,
+                                }
+                            }
+                        }
+                    }
+                    _ => {
+                        println!("⚠️  Not a BIP 44 derivation path");
+                        false
+                    }
+                };
+                println!(
+                    " - Extended public key: {}",
+                    xpub.to_extended_key(bip32::Prefix::XPUB),
+                );
+                println!("   - Depth: {}", xpub.attrs().depth);
+                println!("   - Child number: {}", xpub.attrs().child_number);
+                println!(
+                    "   - Public key: {}",
+                    hex::encode(xpub.public_key().to_bytes())
+                );
+                if show_address {
+                    println!(
+                        " - P2PKH address: {}",
+                        ZcashAddress::from_transparent_p2pkh(
+                            params.network_type(),
+                            ripemd::Ripemd160::digest(Sha256::digest(xpub.public_key().to_bytes()))
+                                .into(),
+                        ),
+                    );
+                }
+            }
+            PoolType::SAPLING => {
+                println!("TODO: Sapling support for whatever might be relevant and useful")
+            }
+            PoolType::ORCHARD => {
+                println!("TODO: Orchard support for whatever might be relevant and useful")
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn parse_pool_type(s: &str) -> anyhow::Result<PoolType> {
+    match s {
+        "transparent" => Ok(PoolType::Transparent),
+        "sapling" => Ok(PoolType::SAPLING),
+        "orchard" => Ok(PoolType::ORCHARD),
+        _ => Err(anyhow!(
+            "Invalid pool type '{s}', must be one of ['transparent', 'sapling', 'orchard']"
+        )),
+    }
+}
+
+fn parse_path(s: &str) -> anyhow::Result<Vec<(u32, bool)>> {
+    s.strip_prefix("m/")
+        .ok_or_else(|| anyhow!("Path does not start with m/"))?
+        .split('/')
+        .map(|index| {
+            let (index, hardened) = if let Some(index) = index.strip_suffix('\'') {
+                (index, true)
+            } else {
+                (index, false)
+            };
+            index
+                .parse::<u32>()
+                .map_err(|e| anyhow!("Invalid path index: {e}"))
+                .map(|index| (index, hardened))
+        })
+        .collect()
+}

--- a/src/commands/wallet/gen_account.rs
+++ b/src/commands/wallet/gen_account.rs
@@ -1,0 +1,78 @@
+use anyhow::anyhow;
+use clap::Args;
+use rand::rngs::OsRng;
+use zcash_client_backend::{data_api::WalletWrite, proto::service};
+use zcash_client_sqlite::{util::SystemClock, WalletDb};
+
+use crate::{
+    commands::wallet,
+    config::WalletConfig,
+    data::get_db_paths,
+    remote::{tor_client, Servers},
+};
+
+// Options accepted for the `generate-account` command
+#[derive(Debug, Args)]
+pub(crate) struct Command {
+    /// age identity file to decrypt the mnemonic phrase with
+    #[arg(short, long)]
+    identity: String,
+
+    /// A name for the account
+    #[arg(long)]
+    name: String,
+
+    /// The server to initialize with (default is \"ecc\")
+    #[arg(short, long)]
+    #[arg(default_value = "ecc", value_parser = Servers::parse)]
+    server: Servers,
+
+    /// Disable connections via TOR
+    #[arg(long)]
+    disable_tor: bool,
+}
+
+impl Command {
+    pub(crate) async fn run(self, wallet_dir: Option<String>) -> anyhow::Result<()> {
+        let mut config = WalletConfig::read(wallet_dir.as_ref())?;
+        let params = config.network();
+
+        let (_, db_data) = get_db_paths(wallet_dir.as_ref());
+        let mut db_data = WalletDb::for_path(db_data, params, SystemClock, OsRng)?;
+
+        // Decrypt the mnemonic to access the seed.
+        let identities = age::IdentityFile::from_file(self.identity)?.into_identities()?;
+        let seed = config
+            .decrypt_seed(identities.iter().map(|i| i.as_ref() as _))?
+            .ok_or(anyhow!(
+                "Seed must be present to enable generating a new account"
+            ))?;
+
+        let server = self.server.pick(params)?;
+        let mut client = if self.disable_tor {
+            server.connect_direct().await?
+        } else {
+            server.connect(|| tor_client(wallet_dir.as_ref())).await?
+        };
+
+        // Get the current chain height (for the wallet's birthday and/or recover-until height).
+        let chain_tip: u32 = client
+            .get_latest_block(service::ChainSpec::default())
+            .await?
+            .into_inner()
+            .height
+            .try_into()
+            .expect("block heights must fit into u32");
+
+        let birthday = wallet::init::Command::get_wallet_birthday(
+            client,
+            chain_tip.saturating_sub(100).into(),
+            None,
+        )
+        .await?;
+
+        db_data.create_account(&self.name, &seed, &birthday, None)?;
+
+        Ok(())
+    }
+}

--- a/src/commands/wallet/gen_addr.rs
+++ b/src/commands/wallet/gen_addr.rs
@@ -14,7 +14,7 @@ use crate::{
 #[cfg(feature = "qr")]
 use qrcode::{render::unicode, QrCode};
 
-// Options accepted for the `list-addresses` command
+// Options accepted for the `generate-address` command
 #[derive(Debug, Args)]
 pub(crate) struct Command {
     /// The UUID of the account to list addresses for

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,9 @@ fn main() -> Result<(), anyhow::Error> {
                 }
                 commands::wallet::Command::Enhance(command) => command.run(wallet_dir).await,
                 commands::wallet::Command::Balance(command) => command.run(wallet_dir).await,
+                commands::wallet::Command::GenerateAccount(command) => {
+                    command.run(wallet_dir).await
+                }
                 commands::wallet::Command::ListAccounts(command) => command.run(wallet_dir),
                 commands::wallet::Command::GenerateAddress(command) => command.run(wallet_dir),
                 commands::wallet::Command::ListAddresses(command) => command.run(wallet_dir),

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,7 @@ fn main() -> Result<(), anyhow::Error> {
                 commands::wallet::Command::ListAccounts(command) => command.run(wallet_dir),
                 commands::wallet::Command::GenerateAddress(command) => command.run(wallet_dir),
                 commands::wallet::Command::ListAddresses(command) => command.run(wallet_dir),
+                commands::wallet::Command::DerivePath(command) => command.run(wallet_dir),
                 commands::wallet::Command::ListTx(command) => command.run(wallet_dir),
                 commands::wallet::Command::ListUnspent(command) => command.run(wallet_dir),
                 commands::wallet::Command::Shield(command) => command.run(wallet_dir).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ pub(crate) enum Command {
     /// Emulate a Keystone device
     #[cfg(feature = "pczt-qr")]
     Keystone(commands::Keystone),
+
+    CreateMultisigAddress(commands::create_multisig_address::Command),
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -116,12 +118,16 @@ fn main() -> Result<(), anyhow::Error> {
 
         let shutdown = ShutdownListener::new();
 
-        match opts.command {
-            Some(Command::Inspect(command)) => command.run().await,
-            Some(Command::Wallet(commands::Wallet {
+        let Some(cmd) = opts.command else {
+            return Ok(());
+        };
+
+        match cmd {
+            Command::Inspect(command) => command.run().await,
+            Command::Wallet(commands::Wallet {
                 wallet_dir,
                 command,
-            })) => match command {
+            }) => match command {
                 commands::wallet::Command::Init(command) => command.run(wallet_dir).await,
                 commands::wallet::Command::InitFvk(command) => command.run(wallet_dir).await,
                 commands::wallet::Command::DisplayMnemonic(command) => command.run(wallet_dir),
@@ -156,10 +162,10 @@ fn main() -> Result<(), anyhow::Error> {
                     commands::wallet::tree::Command::Fix(command) => command.run(wallet_dir).await,
                 },
             },
-            Some(Command::Pczt(commands::Pczt {
+            Command::Pczt(commands::Pczt {
                 wallet_dir,
                 command,
-            })) => match command {
+            }) => match command {
                 commands::pczt::Command::Create(command) => command.run(wallet_dir).await,
                 commands::pczt::Command::Shield(command) => command.run(wallet_dir).await,
                 commands::pczt::Command::Inspect(command) => command.run(wallet_dir).await,
@@ -182,15 +188,16 @@ fn main() -> Result<(), anyhow::Error> {
                 commands::pczt::Command::FromQr(command) => command.run(shutdown).await,
             },
             #[cfg(feature = "pczt-qr")]
-            Some(Command::Keystone(commands::Keystone {
+            Command::Keystone(commands::Keystone {
                 wallet_dir,
                 command,
-            })) => match command {
+            }) => match command {
                 commands::keystone::Command::Enroll(command) => {
                     command.run(shutdown, wallet_dir).await
                 }
             },
-            None => Ok(()),
+
+            Command::CreateMultisigAddress(command) => command.run(),
         }
     })
 }


### PR DESCRIPTION
## Motivation

We want to add a command that generates multisig addresses from an `nrequired` threshold and a list of public keys.

Closes #101.

## Solution

- Adds a `create-multisig-address` command similar to the `createmultisigaddress` RPC method in zcashd
- Adds a `wallet generate-account` subcommand for generating extra transparent addresses to use in testing


## Testing

Manually tested against the `createmultisigaddress` RPC method in zcashd with 3 public keys and a threshold of 2.

## Follow Up Work

Add a `wallet` subcommand that adds the multisig address to the wallet and accepts known p2pkh addresses as well as public keys