### PR TITLE
wallet init: Use rpassword to enter mnemonic instead of CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4920,6 +4920,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rqrr"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4949,6 +4960,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8020,6 +8041,7 @@ dependencies = [
  "rayon",
  "ripemd 0.1.3",
  "roaring",
+ "rpassword",
  "rqrr",
  "rusqlite",
  "rust_decimal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rand = { version = "0.8", default-features = false }
 # Seed encryption
 age = { version = "0.11", features = ["armor", "plugin"] }
 chrono = "0.4"
+rpassword = "7"
 
 # Currency conversion
 iso_currency = { version = "0.5", features = ["with-serde"] }


### PR DESCRIPTION
This helps to prevent the mnemonic from being stored unencrypted in the shell's history file.