### PR TITLE
fix(memo): handle errors when memo to t-address

### DIFF
--- a/src/commands/pczt/create.rs
+++ b/src/commands/pczt/create.rs
@@ -92,7 +92,7 @@ impl Command {
             None,
             vec![],
         )
-        .ok_or_else(|| anyhow!("Invalid memo"))?])
+        .ok_or_else(|| error::Error::TransparentMemo(0))?])
         .map_err(error::Error::from)?;
 
         let proposal = propose_transfer(

--- a/src/commands/wallet/send.rs
+++ b/src/commands/wallet/send.rs
@@ -142,7 +142,7 @@ impl Command {
             None,
             vec![],
         )
-        .expect("payment construction is valid");
+        .ok_or_else(|| error::Error::TransparentMemo(0))?;
         let request = TransactionRequest::new(vec![payment]).map_err(error::Error::from)?;
 
         let proposal = propose_transfer(

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,7 @@ pub enum Error {
     InvalidTreeState,
     SendFailed { code: i32, reason: String },
     Shield(ShieldErrorT),
+    TransparentMemo(usize),
     Wallet(WalletErrorT),
     Zip321(Zip321Error),
 }
@@ -55,6 +56,9 @@ impl fmt::Display for Error {
             Error::InvalidKeysFile => write!(f, "Invalid keys file"),
             Error::InvalidTreeState => write!(f, "Invalid TreeState received from server"),
             Error::SendFailed { code, reason } => write!(f, "Send failed: ({code}) {reason}"),
+            Error::TransparentMemo(idx) => {
+                write!(f, "Payment {idx} invalid: can't send memo to a t-address")
+            }
             Error::Shield(e) => e.fmt(f),
             Error::Wallet(e) => e.fmt(f),
             Error::Zip321(e) => write!(f, "{e:?}"),


### PR DESCRIPTION
This PR addresses https://github.com/zcash/zcash-devtool/issues/95, after making changes to `Payment::new` in `librustzcash`, https://github.com/zcash/librustzcash/pull/2043 it was decided that it correctly returns `Option`. I've updated the caller in the devtool to return `Err(Error::TransparentMemo(0))` after that discussion. Since we create a vector with a single payment in both cases, we fix the payment index to `0`.