### PR TITLE
Don't require ALPN to be configured by the lightwalletd server

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -144,6 +144,7 @@ impl Server<'_> {
         let channel = if self.use_tls() {
             let tls = ClientTlsConfig::new()
                 .domain_name(self.host.to_string())
+                .assume_http2(true)
                 .with_webpki_roots();
             channel.tls_config(tls)?
         } else {


### PR DESCRIPTION
We don't care about extra round trips in the devtool; it is more important that we can connect at all.