### PR TITLE
Add `--tx-version` option to `wallet send` and `wallet pay` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambassador"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68de4cdc6006162265d0957edb4a860fe4e711b1dc17a5746fd95f952f08285"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "amplify"
 version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "blake2b_simd",
  "core2 0.3.3",
@@ -2150,7 +2162,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3234,6 +3246,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -4036,6 +4057,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
+ "proptest",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "reddsa",
@@ -4195,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -5438,6 +5460,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "memuse",
+ "proptest",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
@@ -8523,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "bech32 0.11.0",
  "bs58",
@@ -8536,9 +8559,11 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.21.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
+ "ambassador",
  "arti-client",
+ "assert_matches",
  "base64 0.22.1",
  "bech32 0.11.0",
  "bip32",
@@ -8557,6 +8582,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "incrementalmerkletree",
+ "jubjub",
  "memuse",
  "nonempty",
  "orchard",
@@ -8564,8 +8590,10 @@ dependencies = [
  "pczt",
  "percent-encoding",
  "postcard",
+ "proptest",
  "prost",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
  "rust_decimal",
@@ -8594,6 +8622,7 @@ dependencies = [
  "zcash_keys",
  "zcash_note_encryption",
  "zcash_primitives",
+ "zcash_proofs",
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
@@ -8603,8 +8632,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.19.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+version = "0.19.2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "bip32",
  "bitflags 2.10.0",
@@ -8650,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "core2 0.3.3",
  "hex",
@@ -8660,7 +8689,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "bech32 0.11.0",
  "bip32",
@@ -8674,6 +8703,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
+ "proptest",
  "rand_core 0.6.4",
  "sapling-crypto",
  "secrecy 0.8.0",
@@ -8702,7 +8732,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -8722,6 +8752,7 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard",
+ "proptest",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
@@ -8744,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8766,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "core2 0.3.3",
  "document-features",
@@ -8807,7 +8838,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "bip32",
  "blake2b_simd",
@@ -8902,7 +8933,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.6.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=77c422f1bd56400c9647f089c87f3776e16fd212#77c422f1bd56400c9647f089c87f3776e16fd212"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0d6e7fdc32321c60fa39b13a3017296a23e205ee#0d6e7fdc32321c60fa39b13a3017296a23e205ee"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ pczt = "0.5"
 sapling = { package = "sapling-crypto", version = "0.6" }
 transparent = { package = "zcash_transparent", version = "0.6", features = ["test-dependencies"] }
 zcash_address = "0.10"
-zcash_client_backend = { version = "0.21", features = ["lightwalletd-tonic-tls-webpki-roots", "orchard", "pczt", "tor"] }
-zcash_client_sqlite = { version = "0.19", features = ["unstable", "orchard", "serde"] }
+zcash_client_backend = { version = "0.21", features = ["lightwalletd-tonic-tls-webpki-roots", "orchard", "pczt", "tor", "unstable"] }
+zcash_client_sqlite = { version = "0.19", features = ["unstable", "orchard", "serde", "test-dependencies"] }
 zcash_keys = { version = "0.12", features = ["orchard", "unstable", "unstable-frost"] }
 zcash_primitives = "0.26"
 zcash_proofs = { version = "0.26", features = ["bundled-prover"] }
@@ -114,16 +114,16 @@ tui = [
 ]
 
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "77c422f1bd56400c9647f089c87f3776e16fd212" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0d6e7fdc32321c60fa39b13a3017296a23e205ee" }

--- a/src/commands/pczt/create.rs
+++ b/src/commands/pczt/create.rs
@@ -103,6 +103,7 @@ impl Command {
             &change_strategy,
             request,
             ConfirmationsPolicy::default(),
+            None,
         )
         .map_err(error::Error::from)?;
 

--- a/src/commands/wallet/pay.rs
+++ b/src/commands/wallet/pay.rs
@@ -6,6 +6,8 @@ use uuid::Uuid;
 
 use zip321::TransactionRequest;
 
+use zcash_primitives::transaction::TxVersion;
+
 use crate::{
     commands::wallet::send::{pay, PaymentContext},
     remote::ConnectionArgs,
@@ -69,6 +71,10 @@ impl PaymentContext for Command {
 
     fn require_confirmation(&self) -> bool {
         !self.disable_confirmation
+    }
+
+    fn tx_version(&self) -> Option<TxVersion> {
+        None
     }
 }
 

--- a/src/commands/wallet/propose.rs
+++ b/src/commands/wallet/propose.rs
@@ -78,6 +78,7 @@ impl Command {
             &change_strategy,
             request,
             ConfirmationsPolicy::default(),
+            None,
         )
         .map_err(error::Error::from)?;
 

--- a/src/commands/wallet/shield.rs
+++ b/src/commands/wallet/shield.rs
@@ -141,6 +141,7 @@ impl Command {
             &SpendingKeys::from_unified_spending_key(usk),
             OvkPolicy::Sender,
             &proposal,
+            None,
         )
         .map_err(error::Error::Shield)?;
 


### PR DESCRIPTION
Threads the new `proposed_version` parameter from librustzcash#2152 through the `send` and `pay` commands, allowing explicit selection of transaction version 4 or 5. Updates librustzcash patches to rev 8bad53b6 and enables the `unstable` feature on `zcash_client_backend`.

Depends on https://github.com/zcash/librustzcash/pull/2152