### PR TITLE
Remove unmaintained ECC testnet server

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -12,8 +12,6 @@ use zcash_protocol::consensus::Network;
 
 use crate::{data::get_tor_dir, socks::SocksConnector};
 
-const ECC_TESTNET: &[Server<'_>] = &[Server::fixed("lightwalletd.testnet.electriccoin.co", 9067)];
-
 const YWALLET_MAINNET: &[Server<'_>] = &[
     Server::fixed("lwd1.zcash-infra.com", 9067),
     Server::fixed("lwd2.zcash-infra.com", 9067),
@@ -36,7 +34,6 @@ const ZEC_ROCKS_TESTNET: &[Server<'_>] = &[Server::fixed("testnet.zec.rocks", 44
 
 #[derive(Clone, Debug)]
 pub(crate) enum ServerOperator {
-    Ecc,
     YWallet,
     ZecRocks,
 }
@@ -44,8 +41,6 @@ pub(crate) enum ServerOperator {
 impl ServerOperator {
     fn servers(&self, network: Network) -> &[Server<'_>] {
         match (self, network) {
-            (ServerOperator::Ecc, Network::MainNetwork) => &[],
-            (ServerOperator::Ecc, Network::TestNetwork) => ECC_TESTNET,
             (ServerOperator::YWallet, Network::MainNetwork) => YWALLET_MAINNET,
             (ServerOperator::YWallet, Network::TestNetwork) => &[],
             (ServerOperator::ZecRocks, Network::MainNetwork) => ZEC_ROCKS_MAINNET,
@@ -63,7 +58,6 @@ pub(crate) enum Servers {
 impl Servers {
     pub(crate) fn parse(s: &str) -> anyhow::Result<Self> {
         match s {
-            "ecc" => Ok(Self::Hosted(ServerOperator::Ecc)),
             "ywallet" => Ok(Self::Hosted(ServerOperator::YWallet)),
             "zecrocks" => Ok(Self::Hosted(ServerOperator::ZecRocks)),
             _ => s
@@ -78,7 +72,7 @@ impl Servers {
                 })
                 .collect::<Option<_>>()
                 .map(Self::Custom)
-                .ok_or(anyhow!("'{}' must be one of ['ecc', 'ywallet', 'zecrocks'], or a comma-separated list of host:port", s)),
+                .ok_or(anyhow!("'{}' must be one of ['ywallet', 'zecrocks'], or a comma-separated list of host:port", s)),
         }
     }
 
@@ -254,8 +248,8 @@ fn parse_connection_mode(s: &str) -> Result<ConnectionMode, String> {
 /// CLI arguments for server connection configuration.
 #[derive(Debug, Args, Clone)]
 pub(crate) struct ConnectionArgs {
-    /// The server to connect to (default is "ecc")
-    #[arg(short, long, default_value = "ecc", value_parser = Servers::parse)]
+    /// The server to connect to (default is "zecrocks")
+    #[arg(short, long, default_value = "zecrocks", value_parser = Servers::parse)]
     pub(crate) server: Servers,
 
     /// Connection mode: "direct", "tor" (default), or "socks5://<host>:<port>"


### PR DESCRIPTION
This server has been offline for a while. Let's improve the devtool's usability by defaulting to online servers.

YWallet also no longer maintains their servers [(see the offline server list)](https://hosh.zec.rocks/zec) but I wanted to keep this PR simple.