### PR TITLE
Allow stdin input for wallet init.

### DIFF
--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -2,6 +2,7 @@ use age::secrecy::ExposeSecret;
 use bip0039::{Count, English, Mnemonic};
 use clap::Args;
 use secrecy::{ExposeSecret as _, SecretString, SecretVec, Zeroize};
+use std::io::{stdin, stdout};
 use tokio::io::AsyncWriteExt;
 use tonic::transport::Channel;
 
@@ -85,7 +86,9 @@ impl Command {
         };
 
         // Parse or create the wallet's mnemonic phrase.
-        let phrase = SecretString::new(rpassword::prompt_password(
+        let phrase = SecretString::new(rpassword::prompt_password_from_bufread(
+            &mut stdin().lock(),
+            &mut stdout(),
             "Enter mnemonic (or just press Enter to generate a new one):",
         )?);
         let (mnemonic, recover_until) = if !phrase.expose_secret().is_empty() {


### PR DESCRIPTION
Fixes #154 

Aiming to create some basic container automation (wallet creation without attaching a TTY) I noticed this change could be made easily within the same crate already being used.

The `.lock()` [method aims to provide exclusive access to the standard input stream](https://doc.rust-lang.org/std/io/struct.Stdin.html#method.lock) by returning a locked handle.

I tested this small change locally and it seemed to work as I expected.