### PR TITLE
Add Dependabot config for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration enabling weekly dependency updates for:

- **cargo**: the Rust crate dependencies (`Cargo.toml` / `Cargo.lock`)
- **github-actions**: the actions used across the CI workflows (`ci.yml`, `speed.yml`, `cache-bump.yml`)

Both ecosystems are scoped to the repo root with a weekly schedule and a 10 open-PR limit.