### PR TITLE
Add regtest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ tui-logger = { version = "0.17", optional = true, features = ["tracing-support"]
 [features]
 default = ["transparent-inputs"]
 qr = ["dep:qrcode"]
+regtest_support = ["zcash_protocol/local-consensus"]
 pczt-qr = ["dep:image", "dep:minicbor", "dep:nokhwa", "dep:qrcode", "dep:rqrr", "dep:ur"]
 transparent-inputs = [
     "zcash_client_sqlite/transparent-inputs",

--- a/feature_requests.md
+++ b/feature_requests.md
@@ -1,0 +1,150 @@
+# Feature requests: CLI surface for the zaino wallet-test client
+
+Audience: the Claude working on this `zcash-devtool` clone (branch
+`add_regtest`). These requests come from the zaino side. zaino's wallet
+integration tests now drive this binary (via `zcash_local_net`'s
+`client::zcash_devtool::ZcashDevtool`, which runs each command as a
+subprocess and parses stdout) to replace zingolib. The regtest +
+non-interactive-init + `--min-confirmations` work already landed and is
+proven end to end (a zaino wallet test funds, sends, and shields through a
+devtool wallet, green in CI). These requests unblock porting the *rest* of
+the suite.
+
+## How this binary is consumed (read first)
+
+`zcash_local_net` shells out to `zcash-devtool wallet <cmd> ...` and **parses
+stdout**. Its `client::zcash_devtool` module has parsers (txid line, balance
+lines, default-address line) pinned by integration tests against the real
+binary. Therefore:
+
+- **Every stdout line this binary prints for a machine-consumed command is an
+  integration contract.** Adding a new parseable line is a feature; changing
+  an existing one silently breaks the consumer. Put machine-facing output on
+  **stdout** in a stable `Label: value` shape (the balance command's existing
+  convention). Decorative/human output (`inspect`'s receiver dump) goes to
+  stderr — keep it there.
+- Each request below names the paired `zcash_local_net` change (a `Client`
+  trait method + parser) for context only; that work lives in the
+  infrastructure repo, not here. Coordinate the exact output string with it.
+
+---
+
+## P0 — Emit a bare single-receiver address per pool
+
+**The one blocker for most of the suite.** Today `wallet list-addresses` and
+`wallet gen-addr` print only the full unified address (all receivers).
+`inspect` decodes the receivers but to stderr, in human prose
+(`" - Receivers:"`), which is not parseable. zaino's tests need, on stdout,
+in a stable shape:
+
+- the wallet's **transparent (P2PKH) receiver**, encoded as a bare
+  transparent address (regtest `tm…`);
+- the wallet's **sapling receiver**, encoded as a bare sapling address
+  (regtest `zregtestsapling…`);
+- the **unified** address (already available; keep it).
+
+### Proposed shape
+
+Add `--receiver <unified|transparent|sapling|orchard>` to `wallet
+list-addresses` (default `unified`, preserving today's output). For a
+requested non-unified receiver, print exactly one line:
+
+```
+Receiver(transparent): tmBsTi2xWTjUdEXnuTceL7fecEQKeWaPDJd
+Receiver(sapling): zregtestsapling1...
+```
+
+(Multiple `--receiver` flags → one line each. Orchard is included for
+completeness; zaino routes orchard via the UA, so it is optional.)
+
+### Implementation hint
+
+The default UA already carries the receivers; this is extraction + bare
+encoding, no new key material:
+
+- `UnifiedAddress::transparent() -> Option<&TransparentAddress>`, then
+  `AddressCodec::encode(&params)` → `tm…` on regtest.
+- `UnifiedAddress::sapling() -> Option<&sapling::PaymentAddress>`, then
+  `Address::Sapling(pa).to_zcash_address(&params).encode()` →
+  `zregtestsapling…`.
+
+Use the wallet's default/last-generated UA (same one `balance` and
+`list-addresses` already resolve) so the emitted receivers belong to the
+account being mined to and funded.
+
+### Why this is P0
+
+It unblocks, in one change, the entire transparent/sapling half of the
+matrix: `send_to_transparent`, `send_to_sapling`, `send_to_all`,
+`check_received_mining_reward_and_send` (sends to a sapling address), and
+every zaino query test that funds via a transparent or sapling recipient
+(the bulk of `fetch_service` / `state_service` / `json_server`). It also
+retires a correctness shortcut: the zaino adapter currently hardcodes the
+faucet's transparent address to the known miner constant
+(`REG_T_ADDR_FROM_ABANDONART`) because it cannot ask the wallet. With this,
+the adapter reads the address from the wallet, which *also* verifies (rather
+than assumes) that the abandon-art wallet derives the transparent receiver
+the miner pays to.
+
+Paired consumer change: a `Client::address(pool)` method + a `Receiver(...)`
+line parser.
+
+---
+
+## P1 — Machine-readable output for `balance` (and `list-tx`)
+
+Not blocking — `zcash_local_net` parses the current text today — but
+hardening. `wallet balance` prints a `{:#?}` debug dump of the whole
+`WalletSummary` followed by `Label: value` lines (`Sapling Spendable:`,
+`Orchard Spendable:`, `Unshielded Spendable:`, `Balance:`, `Height:`). The
+debug dump in particular is unstable across `zcash_client_*` upgrades and
+sits in the middle of the parsed output.
+
+Request: a `--json` flag on `wallet balance` emitting a stable object, e.g.
+
+```json
+{ "total": 250000, "sapling_spendable": 0, "orchard_spendable": 250000,
+  "transparent_spendable": 0, "chain_tip_height": 4 }
+```
+
+(Field names matching the consumer's `WalletBalance` struct would let the
+parser switch from line-scraping to `serde_json`.) The same `--json` on
+`wallet list-tx` (emitting `[{ "txid": "...", "mined_height": N }, ...]`)
+would let zaino reproduce the one remaining wallet-oracle assertion
+(`transaction_summaries` in the `get_address_utxos` tests) without text
+parsing. Lower priority than the balance `--json`.
+
+Paired consumer change: swap the hand-rolled stdout parsers for `serde_json`
+when `--json` is present.
+
+---
+
+## P2 — (Known gap, likely out of scope) Mempool / unconfirmed balances
+
+One zaino test (`monitor_unverified_mempool`) broadcasts two transactions
+*without mining*, then asserts the recipient wallet shows them as
+**unconfirmed** per-pool balances. `wallet sync` here is block-based
+(`zcash_client_backend`) and does not scan the mempool, so there is no
+unconfirmed balance to report. Surfacing mempool state would be a large
+change well beyond regtest plumbing.
+
+Recommendation: **do not attempt this for the port.** That single test stays
+on zingolib, or is re-scoped on the zaino side to assert against zaino's own
+mempool gRPC views rather than a wallet. Listed here only so the gap is
+documented and not rediscovered.
+
+---
+
+## Suggested order
+
+1. **P0 receiver addresses** — small, mechanical, unblocks the majority of
+   the remaining zaino wallet tests. Do this first.
+2. **P1 `balance --json`** — removes the most fragile parse surface; do
+   alongside or just after P0.
+3. **P1 `list-tx --json`** — only if the `get_address_utxos` oracle tests
+   are being ported.
+4. **P2 mempool** — skip; documented as a non-goal.
+
+Coordinate the exact stdout strings for P0/P1 with the `zcash_local_net`
+`client::zcash_devtool` parsers (infrastructure repo, branch
+`add_client_support`) so the contract and its pinning tests move together.

--- a/feature_requests_round2.md
+++ b/feature_requests_round2.md
@@ -1,0 +1,114 @@
+# Feature requests (round 2): unblock the rest of the zaino wallet-test port
+
+Audience: the Claude on this `zcash-devtool` clone (branch `add_regtest`).
+Round 1 (`feature_requests.md`: regtest network, non-interactive init,
+`--min-confirmations`, `--receiver`, `--json`) is done and in use — zaino now
+drives this binary via `zcash_local_net` for ~31 wallet tests. These requests
+unblock the test families that remain deferred.
+
+zaino consumes this binary as a subprocess through
+`zcash_local_net::client::zcash_devtool`; **stdout shapes are an integration
+contract** (round-1 rule still applies). Each item below names the zaino tests
+it unblocks.
+
+---
+
+## P0 — Accept regtest activation heights at init (don't hardcode them)
+
+**The single biggest blocker.** The `regtest_support` build currently bakes in
+one set of activation heights. `zcash_local_net`'s `ZcashDevtoolConfig`
+mirrors them in `supported_regtest_activation_heights()` and **rejects** a
+launch whose heights differ (`ClientError::UnsupportedActivationHeights`).
+
+Consequence: the wallet only works against a validator launched with exactly
+those heights. zaino's **zebrad** sessions match, so they work. zaino's
+**zcashd** sessions launch with zcashd's *default* regtest heights, which
+differ — so every zcashd-backed test (the entire `json_server` mod, plus the
+zcashd column of the send/query matrix) is unportable.
+
+### Request
+
+Let `init` (and any command that constructs the wallet's consensus params for
+`-n regtest`) take the activation heights as input rather than compiling them
+in. A `LocalNetwork`-shaped set: the activation height per network upgrade
+(BeforeOverwinter/Overwinter/Sapling/Blossom/Heartwood/Canopy/NU5/NU6/NU6.1/
+NU6.2/NU7). `zcash_protocol`'s `local-consensus` `LocalNetwork` already models
+exactly this and is already in the dependency tree — the regtest params just
+need to come from config instead of a constant.
+
+Interface (any of these works; coordinate the exact shape with
+`zcash_local_net`):
+- a `--activation-heights <toml|json file>` flag on `init`, or
+- repeatable `--activation-height <upgrade>=<height>` args, or
+- a small config file the wallet dir already persists, written at `init`.
+
+Persist the chosen heights in the wallet config so later commands agree.
+
+### What it unblocks
+
+The entire zcashd half of the matrix — `json_server` (its whole mod) and every
+zcashd variant of the send/query tests. `zcash_local_net` would then pass the
+session's actual heights to the client instead of asserting a constant.
+
+---
+
+## P1 — Confirm (and if needed, enable) detection + shielding of transparent coinbase
+
+Some zaino tests mine to a **transparent** miner address
+(`REG_T_ADDR_FROM_ABANDONART`, the abandon-art seed's transparent receiver)
+and fund the wallet by maturing that coinbase and **shielding** it
+(`send_to_transparent`'s finalization variant, `address_deltas`, the
+`test_vectors` chain builder). This requires the faucet wallet to:
+
+1. derive the transparent receiver equal to `REG_T_ADDR_FROM_ABANDONART`
+   (round-1 `--receiver transparent` should already give this — please
+   confirm it equals that constant for the abandon-art seed), and
+2. **detect** the coinbase outputs paid to that address during `sync`, and
+3. **shield** them (mature transparent coinbase -> orchard).
+
+`zcash_client_sqlite`'s `transparent-inputs` feature should cover (2)/(3), but
+this path has never been exercised here. **First, just confirm it works**: a
+`wallet balance` showing the matured transparent coinbase after syncing a
+transparent-mined regtest chain, then a successful `shield`. If it already
+works, this is a no-op (and zaino unblocks a batch with no devtool change). If
+it does **not** (coinbase not credited, or shield refuses transparent coinbase),
+that is the gap to close — enable transparent-coinbase scanning/spending for
+regtest.
+
+### What it unblocks (only if a gap is found and fixed)
+
+The transparent-mining family: `send_to_transparent` (finalization), the
+`state_service` faucet-taddr query tests, `address_deltas`, and the
+`test_vectors` builder.
+
+> Note: the faucet-taddr *query* tests that only need the address string (not a
+> spend) may already be portable on zaino's side once we confirm item (1); we
+> will handle those without a devtool change.
+
+---
+
+## P2 — (Low priority, large) Unconfirmed / mempool balances
+
+`monitor_unverified_mempool` broadcasts transactions without mining and asserts
+the recipient wallet reports them as **unconfirmed** per-pool balances.
+`wallet sync` is block-based (`zcash_client_backend`) and does not scan the
+mempool, so there is nothing to report. Surfacing mempool state is a large
+change well beyond regtest plumbing.
+
+Recommendation: **do not attempt.** That one test stays on zingolib or is
+re-scoped to assert against zaino's own mempool views. Listed only so the gap
+is documented.
+
+---
+
+## Order
+
+1. **P0 activation heights** — unblocks the most (the whole zcashd matrix);
+   smallest, most mechanical given `local-consensus` is already a dependency.
+2. **P1 transparent coinbase** — start by *confirming*; only implement if a gap
+   is found.
+3. **P2 mempool** — skip.
+
+Coordinate the P0 config/flag shape with `zcash_local_net`
+(`client::zcash_devtool`, infrastructure branch `add_client_support`) so the
+contract and its pinning tests move together.

--- a/src/commands/create_multisig_address.rs
+++ b/src/commands/create_multisig_address.rs
@@ -15,7 +15,6 @@ use sha2::{Digest, Sha256};
 
 use transparent::address::TransparentAddress;
 use zcash_keys::encoding::AddressCodec;
-use zcash_protocol::consensus::Network;
 use zcash_script::{
     pattern::check_multisig,
     script::{self, Evaluable},
@@ -54,7 +53,7 @@ impl Command {
         } = self;
 
         let (multisig_script, addr) = multisig_script(threshold, pub_keys)?;
-        let addr = addr.encode(&Network::from(network));
+        let addr = addr.encode(&network);
         println!("Created multisig address: {addr}");
         println!("Redeem script: {}", hex::encode(multisig_script.to_bytes()));
 

--- a/src/commands/pczt/create_manual.rs
+++ b/src/commands/pczt/create_manual.rs
@@ -57,7 +57,8 @@ pub(crate) struct Command {
     #[arg(long)]
     memo: Option<String>,
 
-    /// The network the coins are from: \"test\" or \"main\".
+    /// The network the coins are from: \"test\", \"main\", or \"regtest\" (requires
+    /// the `regtest_support` feature).
     ///
     /// If unset, uses the network of the provided wallet.
     #[arg(short, long)]
@@ -71,7 +72,7 @@ pub(crate) struct Command {
 impl Command {
     pub(crate) async fn run(self, wallet_dir: Option<String>) -> anyhow::Result<()> {
         let params = if let Some(network) = self.network {
-            consensus::Network::from(network)
+            network
         } else {
             let config = WalletConfig::read(wallet_dir.as_ref())?;
             config.network()

--- a/src/commands/pczt/pay_manual.rs
+++ b/src/commands/pczt/pay_manual.rs
@@ -56,7 +56,8 @@ pub(crate) struct Command {
     #[arg(long)]
     change_address: String,
 
-    /// The network the coins are from: \"test\" or \"main\".
+    /// The network the coins are from: \"test\", \"main\", or \"regtest\" (requires
+    /// the `regtest_support` feature).
     ///
     /// If unset, uses the network of the provided wallet.
     #[arg(short, long)]
@@ -70,7 +71,7 @@ pub(crate) struct Command {
 impl Command {
     pub(crate) async fn run(self, wallet_dir: Option<String>) -> anyhow::Result<()> {
         let params = if let Some(network) = self.network {
-            consensus::Network::from(network)
+            network
         } else {
             let config = WalletConfig::read(wallet_dir.as_ref())?;
             config.network()

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -7,6 +7,7 @@ pub(crate) mod display_mnemonic;
 pub(crate) mod enhance;
 pub(crate) mod gen_account;
 pub(crate) mod gen_addr;
+pub(crate) mod get_info;
 pub(crate) mod import_ufvk;
 pub(crate) mod init;
 pub(crate) mod init_fvk;
@@ -42,6 +43,9 @@ pub(crate) enum Command {
 
     /// Upgrade an existing light wallet
     Upgrade(upgrade::Command),
+
+    /// Report server and chain info as JSON (server URI, chain name, chain tip height)
+    GetInfo(get_info::Command),
 
     /// Scan the chain and sync the wallet
     Sync(sync::Command),

--- a/src/commands/wallet/balance.rs
+++ b/src/commands/wallet/balance.rs
@@ -33,6 +33,11 @@ pub(crate) struct Command {
     /// standard policy (3 trusted / 10 untrusted).
     #[arg(long)]
     min_confirmations: Option<std::num::NonZeroU32>,
+
+    /// Emit a single-line JSON object with raw zatoshi values instead of the
+    /// human-readable summary. Ignores `--convert`.
+    #[arg(long)]
+    json: bool,
 }
 
 impl Command {
@@ -48,11 +53,14 @@ impl Command {
             UnifiedAddressRequest::AllAvailableKeys,
         )?;
 
-        let printer = if let Some(currency) = self.convert {
-            let tor = tor_client(wallet_dir.as_ref()).await?;
-            ValuePrinter::with_exchange_rate(&tor, currency).await?
-        } else {
-            ValuePrinter::ZecOnly
+        // In JSON mode we emit raw zatoshis, so skip the exchange-rate fetch
+        // (which would otherwise spin up a Tor client) entirely.
+        let printer = match self.convert {
+            Some(currency) if !self.json => {
+                let tor = tor_client(wallet_dir.as_ref()).await?;
+                ValuePrinter::with_exchange_rate(&tor, currency).await?
+            }
+            _ => ValuePrinter::ZecOnly,
         };
 
         let confirmations_policy = self
@@ -60,6 +68,27 @@ impl Command {
             .map_or_else(ConfirmationsPolicy::default, |n| {
                 ConfirmationsPolicy::new_symmetrical(n, true)
             });
+
+        if self.json {
+            let wallet_summary = db_data
+                .get_wallet_summary(confirmations_policy)?
+                .ok_or_else(|| anyhow!("Insufficient information to build a wallet summary."))?;
+            let balance = wallet_summary
+                .account_balances()
+                .get(&account.id())
+                .ok_or_else(|| anyhow!("Missing account 0"))?;
+
+            let json = serde_json::json!({
+                "total": balance.total().into_u64(),
+                "sapling_spendable": balance.sapling_balance().spendable_value().into_u64(),
+                "orchard_spendable": balance.orchard_balance().spendable_value().into_u64(),
+                "transparent_spendable": balance.unshielded_balance().spendable_value().into_u64(),
+                "chain_tip_height": u32::from(wallet_summary.chain_tip_height()),
+            });
+            println!("{}", serde_json::to_string(&json)?);
+            return Ok(());
+        }
+
         if let Some(wallet_summary) = db_data.get_wallet_summary(confirmations_policy)? {
             let balance = wallet_summary
                 .account_balances()

--- a/src/commands/wallet/balance.rs
+++ b/src/commands/wallet/balance.rs
@@ -27,6 +27,12 @@ pub(crate) struct Command {
     #[arg(long)]
     #[arg(value_parser = parse_currency)]
     convert: Option<Currency>,
+
+    /// Minimum confirmations required for notes to count as spendable,
+    /// applied to trusted and untrusted notes alike. Defaults to the
+    /// standard policy (3 trusted / 10 untrusted).
+    #[arg(long)]
+    min_confirmations: Option<std::num::NonZeroU32>,
 }
 
 impl Command {
@@ -49,7 +55,12 @@ impl Command {
             ValuePrinter::ZecOnly
         };
 
-        if let Some(wallet_summary) = db_data.get_wallet_summary(ConfirmationsPolicy::default())? {
+        let confirmations_policy = self
+            .min_confirmations
+            .map_or_else(ConfirmationsPolicy::default, |n| {
+                ConfirmationsPolicy::new_symmetrical(n, true)
+            });
+        if let Some(wallet_summary) = db_data.get_wallet_summary(confirmations_policy)? {
             let balance = wallet_summary
                 .account_balances()
                 .get(&account.id())

--- a/src/commands/wallet/enhance.rs
+++ b/src/commands/wallet/enhance.rs
@@ -18,7 +18,7 @@ use zcash_client_backend::{
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
 use zcash_keys::encoding::AddressCodec;
 use zcash_primitives::transaction::{Transaction, TxId};
-use zcash_protocol::consensus::{BlockHeight, BranchId, Network};
+use zcash_protocol::consensus::{BlockHeight, BranchId, Parameters};
 
 use crate::{config::get_wallet_network, data::get_db_paths, remote::ConnectionArgs};
 
@@ -29,8 +29,8 @@ pub(crate) struct Command {
     connection: ConnectionArgs,
 }
 
-fn parse_raw_transaction(
-    params: &Network,
+fn parse_raw_transaction<P: Parameters>(
+    params: &P,
     chain_tip: BlockHeight,
     tx: RawTransaction,
 ) -> Result<(Transaction, Option<BlockHeight>), anyhow::Error> {
@@ -46,9 +46,9 @@ fn parse_raw_transaction(
     Ok((tx, mined_height))
 }
 
-async fn fetch_transaction(
+async fn fetch_transaction<P: Parameters>(
     client: &mut CompactTxStreamerClient<Channel>,
-    params: &Network,
+    params: &P,
     chain_tip: BlockHeight,
     txid: TxId,
 ) -> Result<Option<(Transaction, Option<BlockHeight>)>, anyhow::Error> {

--- a/src/commands/wallet/get_info.rs
+++ b/src/commands/wallet/get_info.rs
@@ -1,0 +1,37 @@
+use clap::Args;
+use zcash_client_backend::proto::service;
+
+use crate::{config::get_wallet_network, remote::ConnectionArgs};
+
+// Options accepted for the `get-info` command
+#[derive(Debug, Args)]
+pub(crate) struct Command {
+    #[command(flatten)]
+    connection: ConnectionArgs,
+}
+
+impl Command {
+    pub(crate) async fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
+        let params = get_wallet_network(wallet_dir.as_ref())?;
+
+        // The server we are about to connect to (for the reported URI).
+        let server_uri = self.connection.server.pick(params)?.uri();
+
+        let mut client = self.connection.connect(params, wallet_dir.as_ref()).await?;
+        let info = client
+            .get_lightd_info(service::Empty {})
+            .await?
+            .into_inner();
+
+        // Stable, machine-consumed shape (see zcash_local_net's
+        // `client::zcash_devtool` GetInfoResponse parser).
+        let json = serde_json::json!({
+            "server_uri": server_uri,
+            "chain_name": info.chain_name,
+            "chain_tip_height": info.block_height,
+        });
+        println!("{}", serde_json::to_string(&json)?);
+
+        Ok(())
+    }
+}

--- a/src/commands/wallet/import_ufvk.rs
+++ b/src/commands/wallet/import_ufvk.rs
@@ -53,7 +53,7 @@ impl Command {
             consensus::NetworkType::Main => Network::Main,
             consensus::NetworkType::Test => Network::Test,
             #[cfg(feature = "regtest_support")]
-            consensus::NetworkType::Regtest => Network::Regtest,
+            consensus::NetworkType::Regtest => Network::default_regtest(),
             #[cfg(not(feature = "regtest_support"))]
             consensus::NetworkType::Regtest => {
                 return Err(anyhow!(

--- a/src/commands/wallet/import_ufvk.rs
+++ b/src/commands/wallet/import_ufvk.rs
@@ -12,7 +12,11 @@ use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_protocol::consensus;
 use zip32::fingerprint::SeedFingerprint;
 
-use crate::{data::get_db_paths, error, parse_hex, remote::ConnectionArgs};
+use crate::{
+    data::{Network, get_db_paths},
+    error, parse_hex,
+    remote::ConnectionArgs,
+};
 
 // Options accepted for the `import-ufvk` command
 #[derive(Debug, Args)]
@@ -46,12 +50,17 @@ impl Command {
         let ufvk = UnifiedFullViewingKey::parse(&ufvk).map_err(|e| anyhow!("{e}"))?;
 
         let params = match network {
-            consensus::NetworkType::Main => Ok(consensus::Network::MainNetwork),
-            consensus::NetworkType::Test => Ok(consensus::Network::TestNetwork),
+            consensus::NetworkType::Main => Network::Main,
+            consensus::NetworkType::Test => Network::Test,
+            #[cfg(feature = "regtest_support")]
+            consensus::NetworkType::Regtest => Network::Regtest,
+            #[cfg(not(feature = "regtest_support"))]
             consensus::NetworkType::Regtest => {
-                Err(anyhow!("UFVK is for regtest, which is unsupported"))
+                return Err(anyhow!(
+                    "UFVK is for regtest, which requires the `regtest_support` feature"
+                ));
             }
-        }?;
+        };
 
         let (_, db_data) = get_db_paths(wallet_dir.as_ref());
         let mut db_data = WalletDb::for_path(db_data, params, SystemClock, OsRng)?;

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -9,7 +9,7 @@ use zcash_client_backend::{
     data_api::{AccountBirthday, WalletWrite},
     proto::service::{self, compact_tx_streamer_client::CompactTxStreamerClient},
 };
-use zcash_protocol::consensus::{self, BlockHeight, Parameters};
+use zcash_protocol::consensus::{BlockHeight, Parameters};
 
 use crate::{
     config::WalletConfig,
@@ -33,7 +33,8 @@ pub(crate) struct Command {
     #[arg(long)]
     birthday: Option<u32>,
 
-    /// The network the wallet will be used with: \"test\" or \"main\" (default is \"test\")
+    /// The network the wallet will be used with: \"test\", \"main\", or \"regtest\"
+    /// (requires the `regtest_support` feature). Default is \"test\".
     #[arg(short, long)]
     #[arg(value_parser = Network::parse)]
     network: Network,
@@ -45,7 +46,7 @@ pub(crate) struct Command {
 impl Command {
     pub(crate) async fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
         let opts = self;
-        let params = consensus::Network::from(opts.network);
+        let params = opts.network;
 
         let mut client = opts.connection.connect(params, wallet_dir.as_ref()).await?;
 
@@ -112,7 +113,7 @@ impl Command {
             recipients.iter().map(|r| r.as_ref() as _),
             &mnemonic,
             birthday.height(),
-            opts.network.into(),
+            opts.network,
         )?;
 
         let seed = {

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -39,6 +39,15 @@ pub(crate) struct Command {
     #[arg(value_parser = Network::parse)]
     network: Network,
 
+    /// Required for `-n regtest`: a TOML file giving the validator's
+    /// activation height per network upgrade (keys: overwinter, sapling,
+    /// blossom, heartwood, canopy, nu5, nu6, nu6_1, nu6_2; a missing key
+    /// means the upgrade is inactive). The heights are persisted in the
+    /// wallet config so later commands agree. Rejected for main/test.
+    #[cfg(feature = "regtest_support")]
+    #[arg(long)]
+    activation_heights: Option<std::path::PathBuf>,
+
     #[command(flatten)]
     connection: ConnectionArgs,
 }
@@ -46,6 +55,27 @@ pub(crate) struct Command {
 impl Command {
     pub(crate) async fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
         let opts = self;
+
+        // Regtest requires explicit activation heights (persisted below so
+        // later commands agree); they are rejected for main/test.
+        #[cfg(feature = "regtest_support")]
+        let params = match opts.network {
+            Network::Regtest(_) => {
+                let path = opts.activation_heights.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("`-n regtest` requires --activation-heights <file>")
+                })?;
+                Network::Regtest(crate::data::load_activation_heights(path)?)
+            }
+            other => {
+                if opts.activation_heights.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "--activation-heights is only valid with `-n regtest`"
+                    ));
+                }
+                other
+            }
+        };
+        #[cfg(not(feature = "regtest_support"))]
         let params = opts.network;
 
         let mut client = opts.connection.connect(params, wallet_dir.as_ref()).await?;
@@ -126,7 +156,7 @@ impl Command {
             recipients.iter().map(|r| r.as_ref() as _),
             &mnemonic,
             birthday.height(),
-            opts.network,
+            params,
         )?;
 
         let seed = {

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -85,10 +85,23 @@ impl Command {
             vec![Box::new(recipient) as _]
         };
 
-        // Parse or create the wallet's mnemonic phrase.
-        let phrase = SecretString::new(rpassword::prompt_password(
-            "Enter mnemonic (or just press Enter to generate a new one):",
-        )?);
+        // Parse or create the wallet's mnemonic phrase. `rpassword`
+        // requires a controlling terminal (it prompts and reads via
+        // /dev/tty, failing with ENXIO when there is none), so when
+        // stdin is not a terminal — automation piping the phrase in,
+        // e.g. the `zcash_local_net` test harness — read a line from
+        // stdin instead.
+        let phrase = if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+            SecretString::new(rpassword::prompt_password(
+                "Enter mnemonic (or just press Enter to generate a new one):",
+            )?)
+        } else {
+            let mut line = String::new();
+            std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut line)?;
+            let phrase = SecretString::new(line.trim().to_string());
+            line.zeroize();
+            phrase
+        };
         let (mnemonic, recover_until) = if !phrase.expose_secret().is_empty() {
             (
                 <Mnemonic<English>>::from_phrase(phrase.expose_secret())?,

--- a/src/commands/wallet/init_fvk.rs
+++ b/src/commands/wallet/init_fvk.rs
@@ -69,7 +69,7 @@ impl Command {
             NetworkType::Main => Network::Main,
             NetworkType::Test => Network::Test,
             #[cfg(feature = "regtest_support")]
-            NetworkType::Regtest => Network::Regtest,
+            NetworkType::Regtest => Network::default_regtest(),
             #[cfg(not(feature = "regtest_support"))]
             NetworkType::Regtest => {
                 return Err(anyhow!(

--- a/src/commands/wallet/init_fvk.rs
+++ b/src/commands/wallet/init_fvk.rs
@@ -7,10 +7,15 @@ use zcash_client_backend::{
     proto::service,
 };
 use zcash_keys::{encoding::decode_extfvk_with_network, keys::UnifiedFullViewingKey};
-use zcash_protocol::consensus::{self, NetworkType};
+use zcash_protocol::consensus::NetworkType;
 use zip32::fingerprint::SeedFingerprint;
 
-use crate::{config::WalletConfig, data::init_dbs, parse_hex, remote::ConnectionArgs};
+use crate::{
+    config::WalletConfig,
+    data::{Network, init_dbs},
+    parse_hex,
+    remote::ConnectionArgs,
+};
 
 // Options accepted for the `init-fvk` command
 #[derive(Debug, Args)]
@@ -61,10 +66,15 @@ impl Command {
             )?;
 
         let network = match network_type {
-            NetworkType::Main => consensus::Network::MainNetwork,
-            NetworkType::Test => consensus::Network::TestNetwork,
+            NetworkType::Main => Network::Main,
+            NetworkType::Test => Network::Test,
+            #[cfg(feature = "regtest_support")]
+            NetworkType::Regtest => Network::Regtest,
+            #[cfg(not(feature = "regtest_support"))]
             NetworkType::Regtest => {
-                return Err(anyhow!("the regtest network is not supported"));
+                return Err(anyhow!(
+                    "the regtest network requires the `regtest_support` feature"
+                ));
             }
         };
 

--- a/src/commands/wallet/list_addresses.rs
+++ b/src/commands/wallet/list_addresses.rs
@@ -1,19 +1,42 @@
-use clap::Args;
+use anyhow::anyhow;
+use clap::{Args, ValueEnum};
 use uuid::Uuid;
 use zcash_client_backend::data_api::Account;
 use zcash_client_sqlite::WalletDb;
-use zcash_keys::keys::UnifiedAddressRequest;
+use zcash_keys::{
+    address::{Address, UnifiedAddress},
+    keys::UnifiedAddressRequest,
+};
 
 use crate::{commands::select_account, config::get_wallet_network, data::get_db_paths};
 
 #[cfg(feature = "qr")]
 use qrcode::{QrCode, render::unicode};
 
+/// Which receiver of the account's unified address to emit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+enum Receiver {
+    /// The full unified address (all available receivers).
+    Unified,
+    /// The transparent (P2PKH) receiver, as a bare transparent address.
+    Transparent,
+    /// The Sapling receiver, as a bare Sapling address.
+    Sapling,
+    /// The Orchard receiver, as a unified address carrying only Orchard.
+    Orchard,
+}
+
 // Options accepted for the `list-addresses` command
 #[derive(Debug, Args)]
 pub(crate) struct Command {
     /// The UUID of the account to list addresses for
     account_id: Option<Uuid>,
+
+    /// Which receiver(s) to emit. May be repeated to emit several. Defaults to
+    /// `unified`, which preserves the full default-address output. Non-unified
+    /// receivers are printed one per line as `Receiver(<pool>): <address>`.
+    #[arg(long, value_enum)]
+    receiver: Vec<Receiver>,
 
     /// A flag indicating whether a QR code should be displayed for the address.
     #[cfg(feature = "qr")]
@@ -28,24 +51,66 @@ impl Command {
         let db_data = WalletDb::for_path(db_data, params, (), ())?;
 
         let account = select_account(&db_data, self.account_id)?;
-
-        println!("Account {:?}", account.id());
         let (ua, _) = account
             .uivk()
             .default_address(UnifiedAddressRequest::AllAvailableKeys)?;
-        let ua_str = ua.encode(&params);
-        println!("     Default Address: {ua_str}");
 
-        #[cfg(feature = "qr")]
-        if self.display_qr {
-            let code = QrCode::new(ua_str)?;
-            let ua_qr = code
-                .render::<unicode::Dense1x2>()
-                .dark_color(unicode::Dense1x2::Light)
-                .light_color(unicode::Dense1x2::Dark)
-                .quiet_zone(true)
-                .build();
-            println!("{}", ua_qr);
+        // An empty `--receiver` list defaults to the unified address, preserving
+        // the historical output.
+        let receivers = if self.receiver.is_empty() {
+            &[Receiver::Unified][..]
+        } else {
+            &self.receiver[..]
+        };
+
+        for receiver in receivers {
+            match receiver {
+                Receiver::Unified => {
+                    println!("Account {:?}", account.id());
+                    let ua_str = ua.encode(&params);
+                    println!("     Default Address: {ua_str}");
+
+                    #[cfg(feature = "qr")]
+                    if self.display_qr {
+                        let code = QrCode::new(ua_str)?;
+                        let ua_qr = code
+                            .render::<unicode::Dense1x2>()
+                            .dark_color(unicode::Dense1x2::Light)
+                            .light_color(unicode::Dense1x2::Dark)
+                            .quiet_zone(true)
+                            .build();
+                        println!("{}", ua_qr);
+                    }
+                }
+                Receiver::Transparent => {
+                    let addr = ua
+                        .transparent()
+                        .ok_or_else(|| anyhow!("Account address has no transparent receiver"))?;
+                    println!(
+                        "Receiver(transparent): {}",
+                        Address::from(*addr).encode(&params)
+                    );
+                }
+                Receiver::Sapling => {
+                    let addr = ua
+                        .sapling()
+                        .ok_or_else(|| anyhow!("Account address has no sapling receiver"))?;
+                    println!(
+                        "Receiver(sapling): {}",
+                        Address::from(*addr).encode(&params)
+                    );
+                }
+                Receiver::Orchard => {
+                    let addr = ua
+                        .orchard()
+                        .ok_or_else(|| anyhow!("Account address has no orchard receiver"))?;
+                    // Orchard receivers have no bare encoding; emit a unified
+                    // address carrying only the Orchard receiver.
+                    let orchard_only = UnifiedAddress::from_receivers(Some(*addr), None, None)
+                        .ok_or_else(|| anyhow!("Failed to encode orchard-only unified address"))?;
+                    println!("Receiver(orchard): {}", orchard_only.encode(&params));
+                }
+            }
         }
 
         Ok(())

--- a/src/commands/wallet/list_tx.rs
+++ b/src/commands/wallet/list_tx.rs
@@ -24,6 +24,12 @@ pub(crate) struct Command {
     /// with one record per output row. Defaults to "text".
     #[arg(short, long)]
     mode: Option<String>,
+
+    /// Emit a single-line JSON array of `{"txid", "mined_height"}` objects
+    /// (`mined_height` is null for unmined transactions). Takes precedence
+    /// over `--mode`.
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -98,16 +104,20 @@ impl Command {
              WHERE txid = :txid",
         )?;
 
-        match mode {
-            ListMode::Text => {
-                println!("Transactions:");
-            }
-            ListMode::Csv => {
-                println!(
-                    "Date,Action,Symbol,Volume,Currency,Account,Total,Price,Fee,FeeCurrency,Memo"
-                );
+        if !self.json {
+            match mode {
+                ListMode::Text => {
+                    println!("Transactions:");
+                }
+                ListMode::Csv => {
+                    println!(
+                        "Date,Action,Symbol,Volume,Currency,Account,Total,Price,Fee,FeeCurrency,Memo"
+                    );
+                }
             }
         }
+
+        let mut json_txs = Vec::new();
         for row in stmt_txs.query_and_then(
             named_params! {":account_uuid": self.account_id },
             |row| -> anyhow::Result<_> {
@@ -150,7 +160,18 @@ impl Command {
             },
         )? {
             let tx = row?;
-            tx.print(mode)?;
+            if self.json {
+                json_txs.push(serde_json::json!({
+                    "txid": tx.txid.to_string(),
+                    "mined_height": tx.mined_height.map(u32::from),
+                }));
+            } else {
+                tx.print(mode)?;
+            }
+        }
+
+        if self.json {
+            println!("{}", serde_json::to_string(&json_txs)?);
         }
 
         Ok(())

--- a/src/commands/wallet/send.rs
+++ b/src/commands/wallet/send.rs
@@ -77,6 +77,15 @@ pub(crate) struct Command {
     #[arg(long)]
     #[arg(value_parser = crate::commands::wallet::send::parse_tx_version)]
     tx_version: Option<TxVersion>,
+
+    /// Minimum confirmations required for notes to be spendable,
+    /// applied to trusted and untrusted notes alike. Defaults to the
+    /// standard policy (3 trusted / 10 untrusted). Lowering this aids
+    /// regtest automation on shallow chains but weakens transaction
+    /// distinguishability protections; prefer the default on public
+    /// networks.
+    #[arg(long)]
+    min_confirmations: Option<std::num::NonZeroU32>,
 }
 
 pub(crate) trait PaymentContext {
@@ -87,6 +96,9 @@ pub(crate) trait PaymentContext {
     fn min_split_output_value(&self) -> u64;
     fn require_confirmation(&self) -> bool;
     fn tx_version(&self) -> Option<TxVersion>;
+    fn confirmations_policy(&self) -> ConfirmationsPolicy {
+        ConfirmationsPolicy::default()
+    }
 }
 
 impl PaymentContext for Command {
@@ -117,6 +129,14 @@ impl PaymentContext for Command {
 
     fn tx_version(&self) -> Option<TxVersion> {
         self.tx_version
+    }
+
+    fn confirmations_policy(&self) -> ConfirmationsPolicy {
+        self.min_confirmations.map_or_else(
+            ConfirmationsPolicy::default,
+            // Allowing zero-conf shielding matches `ConfirmationsPolicy::MIN`.
+            |n| ConfirmationsPolicy::new_symmetrical(n, true),
+        )
     }
 }
 
@@ -210,7 +230,7 @@ pub(crate) async fn pay<C: PaymentContext>(
         &input_selector,
         &change_strategy,
         request,
-        ConfirmationsPolicy::default(),
+        context.confirmations_policy(),
         context.tx_version(),
     )
     .map_err(error::Error::from)?;

--- a/src/commands/wallet/tree/explore.rs
+++ b/src/commands/wallet/tree/explore.rs
@@ -22,15 +22,12 @@ use tracing::{info, warn};
 use zcash_client_backend::data_api::{WalletCommitmentTrees, WalletRead};
 use zcash_client_sqlite::{WalletDb, wallet::commitment_tree::SqliteShardStore};
 use zcash_primitives::merkle_tree::HashSer;
-use zcash_protocol::{
-    ShieldedProtocol,
-    consensus::{BlockHeight, Network},
-};
+use zcash_protocol::{ShieldedProtocol, consensus::BlockHeight};
 
 use crate::{
     ShutdownListener,
     config::get_wallet_network,
-    data::get_db_paths,
+    data::{Network, get_db_paths},
     tui::{self, Tui},
 };
 

--- a/src/commands/zip48/init.rs
+++ b/src/commands/zip48/init.rs
@@ -23,7 +23,8 @@ pub(crate) struct Command {
     #[arg(long, required = false)]
     new: bool,
 
-    /// The network the wallet will be used with: \"test\" or \"main\"
+    /// The network the wallet will be used with: \"test\", \"main\", or \"regtest\"
+    /// (requires the `regtest_support` feature)
     #[arg(short, long)]
     #[arg(value_parser = Network::parse)]
     network: Network,
@@ -31,7 +32,7 @@ pub(crate) struct Command {
 
 impl Command {
     pub(crate) fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
-        let params = consensus::Network::from(self.network);
+        let params = self.network;
 
         let recipients = if fs::exists(&self.identity)? {
             age::IdentityFile::from_file(self.identity)?.to_recipients()?
@@ -77,7 +78,7 @@ impl Command {
             params
                 .activation_height(consensus::NetworkUpgrade::Nu6)
                 .expect("active"),
-            self.network.into(),
+            self.network,
         )?;
 
         // Initialise the block and wallet DBs.

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ use crate::{
 const KEYS_FILE: &str = "keys.toml";
 
 pub(crate) struct WalletConfig {
-    network: consensus::Network,
+    network: Network,
     seed_ciphertext: Option<String>,
     birthday: BlockHeight,
 }
@@ -28,7 +28,7 @@ impl WalletConfig {
         recipients: impl Iterator<Item = &'a dyn age::Recipient>,
         mnemonic: &Mnemonic,
         birthday: BlockHeight,
-        network: consensus::Network,
+        network: Network,
     ) -> Result<(), anyhow::Error> {
         init_wallet_config(
             wallet_dir,
@@ -41,7 +41,7 @@ impl WalletConfig {
     pub(crate) fn init_without_mnemonic<P: AsRef<Path>>(
         wallet_dir: Option<P>,
         birthday: BlockHeight,
-        network: consensus::Network,
+        network: Network,
     ) -> Result<(), anyhow::Error> {
         init_wallet_config(wallet_dir, None, birthday, network)
     }
@@ -66,7 +66,7 @@ impl WalletConfig {
             .transpose()
     }
 
-    pub(crate) fn network(&self) -> consensus::Network {
+    pub(crate) fn network(&self) -> Network {
         self.network
     }
 
@@ -79,7 +79,7 @@ fn init_wallet_config<P: AsRef<Path>>(
     wallet_dir: Option<P>,
     mnemonic: Option<String>,
     birthday: BlockHeight,
-    network: consensus::Network,
+    network: Network,
 ) -> Result<(), anyhow::Error> {
     // Create the wallet directory.
     let wallet_dir = wallet_dir
@@ -97,7 +97,7 @@ fn init_wallet_config<P: AsRef<Path>>(
 
     let config = ConfigEncoding {
         mnemonic,
-        network: Some(Network::from(network).name().to_string()),
+        network: Some(network.name().to_string()),
         birthday: Some(u32::from(birthday)),
     };
 
@@ -126,11 +126,9 @@ impl WalletConfig {
         let config: ConfigEncoding = toml::from_str(&conf_str)?;
 
         let network = config.network.map_or_else(
-            || Ok(consensus::Network::TestNetwork),
+            || Ok(Network::Test),
             |network_name| {
-                Network::parse(network_name.trim())
-                    .map(consensus::Network::from)
-                    .map_err(|_| error::Error::InvalidKeysFile)
+                Network::parse(network_name.trim()).map_err(|_| error::Error::InvalidKeysFile)
             },
         )?;
 
@@ -203,7 +201,7 @@ fn decrypt_seed<'a>(
 
 pub(crate) fn get_wallet_network<P: AsRef<Path>>(
     wallet_dir: Option<P>,
-) -> Result<consensus::Network, anyhow::Error> {
+) -> Result<Network, anyhow::Error> {
     Ok(WalletConfig::read(wallet_dir)?.network)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use zcash_protocol::consensus::{self, BlockHeight, Parameters};
 
+#[cfg(feature = "regtest_support")]
+use crate::data::ActivationHeights;
 use crate::{
     data::{DEFAULT_WALLET_DIR, Network},
     error,
@@ -99,6 +101,11 @@ fn init_wallet_config<P: AsRef<Path>>(
         mnemonic,
         network: Some(network.name().to_string()),
         birthday: Some(u32::from(birthday)),
+        #[cfg(feature = "regtest_support")]
+        activation_heights: match network {
+            Network::Regtest(local) => Some(ActivationHeights::from_local_network(local)),
+            _ => None,
+        },
     };
 
     let config_str = toml::to_string(&config)
@@ -125,18 +132,31 @@ impl WalletConfig {
         keys_file.read_to_string(&mut conf_str)?;
         let config: ConfigEncoding = toml::from_str(&conf_str)?;
 
-        let network = config.network.map_or_else(
+        let network = config.network.as_deref().map_or_else(
             || Ok(Network::Test),
             |network_name| {
                 Network::parse(network_name.trim()).map_err(|_| error::Error::InvalidKeysFile)
             },
         )?;
 
-        let birthday = config.birthday.map(BlockHeight::from).unwrap_or(
+        // For regtest, replace the parsed default heights with the ones
+        // persisted at `init` so this command agrees with the wallet's chain.
+        #[cfg(feature = "regtest_support")]
+        let network = match network {
+            Network::Regtest(_) => Network::Regtest(
+                config
+                    .activation_heights
+                    .ok_or(error::Error::InvalidKeysFile)?
+                    .to_local_network(),
+            ),
+            other => other,
+        };
+
+        let birthday = config.birthday.map(BlockHeight::from).unwrap_or_else(|| {
             network
                 .activation_height(consensus::NetworkUpgrade::Sapling)
-                .expect("Sapling activation height is known."),
-        );
+                .expect("Sapling activation height is known.")
+        });
 
         Ok(Self {
             network,
@@ -151,6 +171,9 @@ struct ConfigEncoding {
     mnemonic: Option<String>,
     network: Option<String>,
     birthday: Option<u32>,
+    /// Regtest activation heights, present only for `network = "regtest"`.
+    #[cfg(feature = "regtest_support")]
+    activation_heights: Option<ActivationHeights>,
 }
 
 fn encrypt_mnemonic<'a>(
@@ -211,4 +234,52 @@ pub(crate) fn get_wallet_seed<'a, P: AsRef<Path>>(
 ) -> Result<Option<SecretVec<u8>>, anyhow::Error> {
     let mut config = WalletConfig::read(wallet_dir)?;
     config.decrypt_seed(identities)
+}
+
+#[cfg(all(test, feature = "regtest_support"))]
+mod tests {
+    use super::*;
+    use zcash_protocol::consensus::NetworkUpgrade;
+
+    /// A regtest wallet config persisted by `init` must carry the activation
+    /// heights into `keys.toml` and reconstruct them on read, so commands
+    /// after `init` build transactions against the same chain.
+    #[test]
+    fn regtest_activation_heights_persist_and_reload() {
+        let dir =
+            std::env::temp_dir().join(format!("zcash-devtool-cfg-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let dir = dir.to_str().unwrap().to_string();
+
+        let heights: ActivationHeights = toml::from_str(
+            "overwinter = 1\nsapling = 1\nblossom = 1\nheartwood = 1\ncanopy = 1\n\
+             nu5 = 2\nnu6 = 2\nnu6_1 = 5\n",
+        )
+        .unwrap();
+        let network = Network::Regtest(heights.to_local_network());
+
+        WalletConfig::init_without_mnemonic(Some(&dir), BlockHeight::from_u32(0), network).unwrap();
+
+        // The persisted file records the heights as a table.
+        let keys_toml = fs::read_to_string(Path::new(&dir).join(KEYS_FILE)).unwrap();
+        assert!(keys_toml.contains("[activation_heights]"), "{keys_toml}");
+
+        let reloaded = WalletConfig::read(Some(&dir)).unwrap();
+        match reloaded.network {
+            Network::Regtest(local) => {
+                assert_eq!(
+                    local.activation_height(NetworkUpgrade::Nu5),
+                    Some(BlockHeight::from_u32(2))
+                );
+                assert_eq!(
+                    local.activation_height(NetworkUpgrade::Nu6_1),
+                    Some(BlockHeight::from_u32(5))
+                );
+                assert_eq!(local.activation_height(NetworkUpgrade::Nu6_2), None);
+            }
+            other => panic!("expected regtest, got {other:?}"),
+        }
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -24,8 +24,11 @@ pub(crate) enum Network {
     #[default]
     Test,
     Main,
+    /// Regtest, carrying the caller-chosen activation heights. These are
+    /// fixed at `init` (from `--activation-heights`) and persisted in the
+    /// wallet config so later commands agree.
     #[cfg(feature = "regtest_support")]
-    Regtest,
+    Regtest(LocalNetwork),
 }
 
 impl Network {
@@ -33,8 +36,12 @@ impl Network {
         match name {
             "main" => Ok(Network::Main),
             "test" => Ok(Network::Test),
+            // `-n regtest` on the CLI yields the default heights; `init`
+            // overrides them from the required `--activation-heights` file
+            // before persisting. Commands that only need the network *type*
+            // (e.g. address encoding) are unaffected by the heights.
             #[cfg(feature = "regtest_support")]
-            "regtest" => Ok(Network::Regtest),
+            "regtest" => Ok(Network::Regtest(DEFAULT_REGTEST)),
             other => Err(format!("Unsupported network: {other}")),
         }
     }
@@ -44,33 +51,30 @@ impl Network {
             Network::Test => "test",
             Network::Main => "main",
             #[cfg(feature = "regtest_support")]
-            Network::Regtest => "regtest",
+            Network::Regtest(_) => "regtest",
         }
+    }
+
+    /// Regtest with the built-in default activation heights, for CLI paths
+    /// (address encoding, UFVK import) that don't take an explicit set.
+    #[cfg(feature = "regtest_support")]
+    pub(crate) fn default_regtest() -> Network {
+        Network::Regtest(DEFAULT_REGTEST)
     }
 }
 
-/// Activation heights matching the regtest configuration used by
-/// wallet-funding zebrad sessions launched via `zcash_local_net`:
-/// pre-NU5 upgrades active at height 1, everything NU5 and later at
-/// height 2.
+/// Fallback regtest activation heights for CLI paths that don't take an
+/// explicit set (see [`Network::default_regtest`]). Wallets created by
+/// `init` do NOT use this — they carry the heights from the required
+/// `--activation-heights` file. These defaults match the `zcash_local_net`
+/// wallet-funding zebrad fixture (pre-NU5 at 1, everything NU5+ at 2).
 ///
-/// Transaction construction picks the consensus branch ID from these
-/// heights, so any drift between this constant and the launched
-/// validator's heights makes the validator reject wallet transactions
-/// built while the tip is inside the drifted window.
-///
-/// Why all-at-2 and not `zcash_local_net`'s *default* fixture (which
-/// puts NU6.1/NU6.2 at height 5): zebra 5.1.0's shielded-coinbase
-/// block templates fail their own orchard-proof verification when a
-/// configured-but-not-yet-active upgrade exists above the template
-/// height ("could not validate orchard proof" on submitblock), so
-/// orchard-mining sessions — the ones wallets are funded from — must
-/// activate every configured upgrade before mining begins. The
-/// harness-side mirror of this constant is
-/// `zcash_local_net::client::zcash_devtool::supported_regtest_activation_heights`,
-/// and its integration tests pin the alignment live.
+/// Transaction construction picks the consensus branch ID from the active
+/// heights, so any drift between a wallet's heights and the launched
+/// validator's makes the validator reject transactions built while the tip
+/// is inside the drifted window.
 #[cfg(feature = "regtest_support")]
-const REGTEST: LocalNetwork = LocalNetwork {
+const DEFAULT_REGTEST: LocalNetwork = LocalNetwork {
     overwinter: Some(BlockHeight::from_u32(1)),
     sapling: Some(BlockHeight::from_u32(1)),
     blossom: Some(BlockHeight::from_u32(1)),
@@ -82,13 +86,77 @@ const REGTEST: LocalNetwork = LocalNetwork {
     nu6_2: Some(BlockHeight::from_u32(2)),
 };
 
+/// A `LocalNetwork`-shaped set of regtest activation heights, one optional
+/// height per network upgrade (a missing entry means "not active"). This is
+/// the schema of the `--activation-heights` TOML file and of the
+/// `[activation_heights]` table persisted in the wallet config; the two share
+/// this type so a wallet's heights round-trip from the file the operator
+/// commits to revision control.
+#[cfg(feature = "regtest_support")]
+#[derive(Clone, Copy, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub(crate) struct ActivationHeights {
+    pub(crate) overwinter: Option<u32>,
+    pub(crate) sapling: Option<u32>,
+    pub(crate) blossom: Option<u32>,
+    pub(crate) heartwood: Option<u32>,
+    pub(crate) canopy: Option<u32>,
+    pub(crate) nu5: Option<u32>,
+    pub(crate) nu6: Option<u32>,
+    pub(crate) nu6_1: Option<u32>,
+    pub(crate) nu6_2: Option<u32>,
+}
+
+#[cfg(feature = "regtest_support")]
+impl ActivationHeights {
+    pub(crate) fn to_local_network(self) -> LocalNetwork {
+        let h = |v: Option<u32>| v.map(BlockHeight::from_u32);
+        LocalNetwork {
+            overwinter: h(self.overwinter),
+            sapling: h(self.sapling),
+            blossom: h(self.blossom),
+            heartwood: h(self.heartwood),
+            canopy: h(self.canopy),
+            nu5: h(self.nu5),
+            nu6: h(self.nu6),
+            nu6_1: h(self.nu6_1),
+            nu6_2: h(self.nu6_2),
+        }
+    }
+
+    pub(crate) fn from_local_network(local: LocalNetwork) -> Self {
+        let h = |v: Option<BlockHeight>| v.map(u32::from);
+        Self {
+            overwinter: h(local.overwinter),
+            sapling: h(local.sapling),
+            blossom: h(local.blossom),
+            heartwood: h(local.heartwood),
+            canopy: h(local.canopy),
+            nu5: h(local.nu5),
+            nu6: h(local.nu6),
+            nu6_1: h(local.nu6_1),
+            nu6_2: h(local.nu6_2),
+        }
+    }
+}
+
+/// Load a `--activation-heights` TOML file into a `LocalNetwork`.
+#[cfg(feature = "regtest_support")]
+pub(crate) fn load_activation_heights(path: &Path) -> anyhow::Result<LocalNetwork> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("reading activation-heights file {path:?}: {e}"))?;
+    let heights: ActivationHeights = toml::from_str(&contents)
+        .map_err(|e| anyhow::anyhow!("parsing activation-heights file {path:?}: {e}"))?;
+    Ok(heights.to_local_network())
+}
+
 impl Parameters for Network {
     fn network_type(&self) -> consensus::NetworkType {
         match self {
             Network::Test => consensus::Network::TestNetwork.network_type(),
             Network::Main => consensus::Network::MainNetwork.network_type(),
             #[cfg(feature = "regtest_support")]
-            Network::Regtest => REGTEST.network_type(),
+            Network::Regtest(local) => local.network_type(),
         }
     }
 
@@ -97,7 +165,7 @@ impl Parameters for Network {
             Network::Test => consensus::Network::TestNetwork.activation_height(nu),
             Network::Main => consensus::Network::MainNetwork.activation_height(nu),
             #[cfg(feature = "regtest_support")]
-            Network::Regtest => REGTEST.activation_height(nu),
+            Network::Regtest(local) => local.activation_height(nu),
         }
     }
 }
@@ -155,4 +223,48 @@ pub(crate) fn init_dbs<P: Parameters + 'static>(
     init_wallet_db(&mut db_data, None)?;
 
     Ok(db_data)
+}
+
+#[cfg(all(test, feature = "regtest_support"))]
+mod tests {
+    use super::*;
+    use consensus::NetworkUpgrade;
+
+    #[test]
+    fn activation_heights_toml_maps_to_local_network() {
+        // A missing key (here nu6_2) means the upgrade is inactive.
+        let toml = "\
+overwinter = 1
+sapling = 1
+blossom = 1
+heartwood = 1
+canopy = 1
+nu5 = 2
+nu6 = 2
+nu6_1 = 2
+";
+        let heights: ActivationHeights = toml::from_str(toml).unwrap();
+        let local = heights.to_local_network();
+        let net = Network::Regtest(local);
+
+        assert_eq!(
+            net.activation_height(NetworkUpgrade::Sapling),
+            Some(BlockHeight::from_u32(1))
+        );
+        assert_eq!(
+            net.activation_height(NetworkUpgrade::Nu5),
+            Some(BlockHeight::from_u32(2))
+        );
+        assert_eq!(net.activation_height(NetworkUpgrade::Nu6_2), None);
+    }
+
+    #[test]
+    fn activation_heights_round_trip_through_local_network() {
+        let original: ActivationHeights = toml::from_str("nu5 = 7\nnu6 = 9\n").unwrap();
+        let restored = ActivationHeights::from_local_network(original.to_local_network());
+        // Restoring from the LocalNetwork preserves set and unset upgrades.
+        assert_eq!(restored.nu5, Some(7));
+        assert_eq!(restored.nu6, Some(9));
+        assert_eq!(restored.sapling, None);
+    }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -49,19 +49,26 @@ impl Network {
     }
 }
 
-/// Activation heights matching the regtest configuration used by zebrad
-/// sessions launched via `zcash_local_net`: pre-NU5 upgrades active at
-/// height 1, NU5/NU6 at height 2, NU6.1/NU6.2 at height 5.
+/// Activation heights matching the regtest configuration used by
+/// wallet-funding zebrad sessions launched via `zcash_local_net`:
+/// pre-NU5 upgrades active at height 1, everything NU5 and later at
+/// height 2.
 ///
-/// NU6.1/NU6.2 sit at height 5 (not 2) because zebrad's
-/// `subsidy_is_valid` rejects the NU6.1 activation block unless the
-/// deferred (lockbox) pool already holds enough to cover the configured
-/// disbursements — `zcash_local_net` leaves three NU6 blocks (2–4) for
-/// its funding stream to deposit into the pool. The authoritative tuple
-/// is `zcash_local_net::validator::regtest_test_activation_heights`;
-/// transaction construction picks the consensus branch ID from these
-/// heights, so any drift makes the validator reject wallet transactions
+/// Transaction construction picks the consensus branch ID from these
+/// heights, so any drift between this constant and the launched
+/// validator's heights makes the validator reject wallet transactions
 /// built while the tip is inside the drifted window.
+///
+/// Why all-at-2 and not `zcash_local_net`'s *default* fixture (which
+/// puts NU6.1/NU6.2 at height 5): zebra 5.1.0's shielded-coinbase
+/// block templates fail their own orchard-proof verification when a
+/// configured-but-not-yet-active upgrade exists above the template
+/// height ("could not validate orchard proof" on submitblock), so
+/// orchard-mining sessions — the ones wallets are funded from — must
+/// activate every configured upgrade before mining begins. The
+/// harness-side mirror of this constant is
+/// `zcash_local_net::client::zcash_devtool::supported_regtest_activation_heights`,
+/// and its integration tests pin the alignment live.
 #[cfg(feature = "regtest_support")]
 const REGTEST: LocalNetwork = LocalNetwork {
     overwinter: Some(BlockHeight::from_u32(1)),
@@ -71,8 +78,8 @@ const REGTEST: LocalNetwork = LocalNetwork {
     canopy: Some(BlockHeight::from_u32(1)),
     nu5: Some(BlockHeight::from_u32(2)),
     nu6: Some(BlockHeight::from_u32(2)),
-    nu6_1: Some(BlockHeight::from_u32(5)),
-    nu6_2: Some(BlockHeight::from_u32(5)),
+    nu6_1: Some(BlockHeight::from_u32(2)),
+    nu6_2: Some(BlockHeight::from_u32(2)),
 };
 
 impl Parameters for Network {

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,7 +8,9 @@ use zcash_client_sqlite::{FsBlockDb, WalletDb};
 use tracing::error;
 
 use zcash_client_sqlite::chain::BlockMeta;
-use zcash_protocol::consensus::{self, Parameters};
+use zcash_protocol::consensus::{self, BlockHeight, Parameters};
+#[cfg(feature = "regtest_support")]
+use zcash_protocol::local_consensus::LocalNetwork;
 
 use crate::error;
 
@@ -22,6 +24,8 @@ pub(crate) enum Network {
     #[default]
     Test,
     Main,
+    #[cfg(feature = "regtest_support")]
+    Regtest,
 }
 
 impl Network {
@@ -29,6 +33,8 @@ impl Network {
         match name {
             "main" => Ok(Network::Main),
             "test" => Ok(Network::Test),
+            #[cfg(feature = "regtest_support")]
+            "regtest" => Ok(Network::Regtest),
             other => Err(format!("Unsupported network: {other}")),
         }
     }
@@ -37,24 +43,54 @@ impl Network {
         match self {
             Network::Test => "test",
             Network::Main => "main",
+            #[cfg(feature = "regtest_support")]
+            Network::Regtest => "regtest",
         }
     }
 }
 
-impl From<Network> for consensus::Network {
-    fn from(value: Network) -> Self {
-        match value {
-            Network::Test => consensus::Network::TestNetwork,
-            Network::Main => consensus::Network::MainNetwork,
+/// Activation heights matching the regtest configuration used by zebrad
+/// sessions launched via `zcash_local_net`: pre-NU5 upgrades active at
+/// height 1, NU5/NU6 at height 2, NU6.1/NU6.2 at height 5.
+///
+/// NU6.1/NU6.2 sit at height 5 (not 2) because zebrad's
+/// `subsidy_is_valid` rejects the NU6.1 activation block unless the
+/// deferred (lockbox) pool already holds enough to cover the configured
+/// disbursements — `zcash_local_net` leaves three NU6 blocks (2–4) for
+/// its funding stream to deposit into the pool. The authoritative tuple
+/// is `zcash_local_net::validator::regtest_test_activation_heights`;
+/// transaction construction picks the consensus branch ID from these
+/// heights, so any drift makes the validator reject wallet transactions
+/// built while the tip is inside the drifted window.
+#[cfg(feature = "regtest_support")]
+const REGTEST: LocalNetwork = LocalNetwork {
+    overwinter: Some(BlockHeight::from_u32(1)),
+    sapling: Some(BlockHeight::from_u32(1)),
+    blossom: Some(BlockHeight::from_u32(1)),
+    heartwood: Some(BlockHeight::from_u32(1)),
+    canopy: Some(BlockHeight::from_u32(1)),
+    nu5: Some(BlockHeight::from_u32(2)),
+    nu6: Some(BlockHeight::from_u32(2)),
+    nu6_1: Some(BlockHeight::from_u32(5)),
+    nu6_2: Some(BlockHeight::from_u32(5)),
+};
+
+impl Parameters for Network {
+    fn network_type(&self) -> consensus::NetworkType {
+        match self {
+            Network::Test => consensus::Network::TestNetwork.network_type(),
+            Network::Main => consensus::Network::MainNetwork.network_type(),
+            #[cfg(feature = "regtest_support")]
+            Network::Regtest => REGTEST.network_type(),
         }
     }
-}
 
-impl From<consensus::Network> for Network {
-    fn from(value: consensus::Network) -> Self {
-        match value {
-            consensus::Network::TestNetwork => Network::Test,
-            consensus::Network::MainNetwork => Network::Main,
+    fn activation_height(&self, nu: consensus::NetworkUpgrade) -> Option<BlockHeight> {
+        match self {
+            Network::Test => consensus::Network::TestNetwork.activation_height(nu),
+            Network::Main => consensus::Network::MainNetwork.activation_height(nu),
+            #[cfg(feature = "regtest_support")]
+            Network::Regtest => REGTEST.activation_height(nu),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,7 @@ fn main() -> Result<(), anyhow::Error> {
                         )
                         .await
                 }
+                commands::wallet::Command::GetInfo(command) => command.run(wallet_dir).await,
                 commands::wallet::Command::Enhance(command) => command.run(wallet_dir).await,
                 commands::wallet::Command::Balance(command) => command.run(wallet_dir).await,
                 commands::wallet::Command::GenerateAccount(command) => {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -53,7 +53,7 @@ impl ServerOperator {
             (ServerOperator::ZecRocks, Network::Test) => ZEC_ROCKS_TESTNET,
             // No operator hosts regtest; users must pass a custom host:port.
             #[cfg(feature = "regtest_support")]
-            (_, Network::Regtest) => &[],
+            (_, Network::Regtest(_)) => &[],
         }
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -133,6 +133,12 @@ impl Server<'_> {
             && !self.host.ends_with(".onion")
     }
 
+    /// The server's connection URI (scheme included), as reported by
+    /// `wallet get-info`.
+    pub(crate) fn uri(&self) -> String {
+        self.endpoint()
+    }
+
     fn endpoint(&self) -> String {
         format!(
             "{}://{}:{}",

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -4,13 +4,14 @@ use anyhow::anyhow;
 use clap::Args;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint, Uri};
 
+use crate::{
+    data::{Network, get_tor_dir},
+    socks::SocksConnector,
+};
 use tracing::{info, warn};
 use zcash_client_backend::{
     proto::service::compact_tx_streamer_client::CompactTxStreamerClient, tor,
 };
-use zcash_protocol::consensus::Network;
-
-use crate::{data::get_tor_dir, socks::SocksConnector};
 
 const ECC_TESTNET: &[Server<'_>] = &[Server::fixed("lightwalletd.testnet.electriccoin.co", 9067)];
 
@@ -44,12 +45,15 @@ pub(crate) enum ServerOperator {
 impl ServerOperator {
     fn servers(&self, network: Network) -> &[Server<'_>] {
         match (self, network) {
-            (ServerOperator::Ecc, Network::MainNetwork) => &[],
-            (ServerOperator::Ecc, Network::TestNetwork) => ECC_TESTNET,
-            (ServerOperator::YWallet, Network::MainNetwork) => YWALLET_MAINNET,
-            (ServerOperator::YWallet, Network::TestNetwork) => &[],
-            (ServerOperator::ZecRocks, Network::MainNetwork) => ZEC_ROCKS_MAINNET,
-            (ServerOperator::ZecRocks, Network::TestNetwork) => ZEC_ROCKS_TESTNET,
+            (ServerOperator::Ecc, Network::Main) => &[],
+            (ServerOperator::Ecc, Network::Test) => ECC_TESTNET,
+            (ServerOperator::YWallet, Network::Main) => YWALLET_MAINNET,
+            (ServerOperator::YWallet, Network::Test) => &[],
+            (ServerOperator::ZecRocks, Network::Main) => ZEC_ROCKS_MAINNET,
+            (ServerOperator::ZecRocks, Network::Test) => ZEC_ROCKS_TESTNET,
+            // No operator hosts regtest; users must pass a custom host:port.
+            #[cfg(feature = "regtest_support")]
+            (_, Network::Regtest) => &[],
         }
     }
 }


### PR DESCRIPTION
In order to support regtest mode for integration-test in zaino, I extended the feature set of devtool.

This upgrade expands the dependencies by (at least) compiling in "local_consensus" from "zcash_protocol".

I am activating NU6.1/NU6.2 at height 5 in my local consensus regtest network by default.

Are these reasonable as regtest default values?

This PR checks in the instructions passed between agents as implementation specs in the implementing commits.

In addition to enabling regtest mode the folloing cli args were added:

list_addresses
balance
list_tx
get_info

This PR also enables setting regtest activation heights at runtime.
