### PR TITLE
Fix build under `--cfg zcash_unstable="nu7"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ rust-version = "1.87"
 license = "MIT OR Apache-2.0"
 publish = false
 
+[lints.rust]
+# `zcash_unstable` is a `--cfg` set via RUSTFLAGS (not a Cargo feature) by the
+# zcash crates to opt in to in-development network upgrades; declared here so the
+# inspect code can gate on NU7 without tripping the `unexpected_cfgs` lint.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("nu7"))'] }
+
 [dependencies]
 anyhow = "1"
 bip0039 = { version = "0.12", features = ["std", "all-languages"] }

--- a/src/commands/inspect/keys.rs
+++ b/src/commands/inspect/keys.rs
@@ -201,6 +201,8 @@ pub(crate) fn inspect_sapling_extsk(data: Vec<u8>, network: NetworkType) {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        #[cfg(zcash_unstable = "nu7")]
+                        nu7: None,
                     }),
                 };
                 eprintln!("- UFVK: {encoded_ufvk}");
@@ -221,6 +223,8 @@ pub(crate) fn inspect_sapling_extsk(data: Vec<u8>, network: NetworkType) {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        #[cfg(zcash_unstable = "nu7")]
+                        nu7: None,
                     }),
                 };
                 eprintln!("  - Default address: {encoded_ua}");

--- a/src/commands/inspect/keys/view.rs
+++ b/src/commands/inspect/keys/view.rs
@@ -121,6 +121,8 @@ pub(crate) fn inspect_sapling_extfvk(data: Vec<u8>, network: NetworkType) {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        #[cfg(zcash_unstable = "nu7")]
+                        nu7: None,
                     }),
                 };
                 eprintln!("- Equivalent UFVK: {encoded_ufvk}");
@@ -141,6 +143,8 @@ pub(crate) fn inspect_sapling_extfvk(data: Vec<u8>, network: NetworkType) {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        #[cfg(zcash_unstable = "nu7")]
+                        nu7: None,
                     }),
                 };
                 eprintln!("  - Default address: {encoded_ua}");

--- a/src/commands/inspect/transaction.rs
+++ b/src/commands/inspect/transaction.rs
@@ -144,6 +144,10 @@ pub(crate) fn inspect(
         TxVersion::V5 => {
             eprintln!(" - Consensus branch ID: {:?}", tx.consensus_branch_id());
         }
+        #[cfg(zcash_unstable = "nu7")]
+        TxVersion::V6 => {
+            eprintln!(" - Consensus branch ID: {:?}", tx.consensus_branch_id());
+        }
     }
 
     let is_coinbase = is_coinbase(&tx);


### PR DESCRIPTION
## Summary

Building `zcash-devtool` with `--cfg zcash_unstable="nu7"` fails to compile. This fixes the `inspect` command so it builds cleanly under the `nu7` configuration.

Closes #173.

## Details

Under `--cfg zcash_unstable="nu7"`, `zcash_protocol`'s `LocalNetwork` gains an `nu7` field and `zcash_primitives`' `TxVersion` gains a `V6` variant. Two sites in `inspect` did not account for this:

- `inspect keys` / `inspect keys view`: four `LocalNetwork` initializers (regtest UFVK/UA encoding) were missing the `nu7` field.
- `inspect transaction`: the `TxVersion` match did not cover `V6`.

The added field and match arm are gated on `zcash_unstable = "nu7"`, and `zcash_unstable` is declared via a `[lints.rust]` check-cfg so the attributes don't trip `unexpected_cfgs` on ordinary builds. There is no behaviour change on default builds.

## Verification

- `cargo clippy --all-targets -- -D warnings` (default) clean.
- `cargo fmt --all -- --check` clean.
- `RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo check` compiles (previously failed with missing-field / non-exhaustive-match errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
