### PR TITLE
Update to librustzcash main (post-TZE-removal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,7 +1770,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "strum 0.27.2",
+ "strum 0.26.3",
  "syn 2.0.117",
  "void",
 ]
@@ -2115,8 +2115,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -2167,8 +2166,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "blake2b_simd",
 ]
@@ -4260,8 +4258,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4712bd8688e1d1aa0eb0e78dc5c846bc2d70dcd1de544ecf053516df174c4fcd"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -8756,8 +8753,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -8770,8 +8766,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04583f0945d5ff80eee80c1844fb0af8b7cc46a0ac26d5e12c4ccd474bec0f03"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "ambassador",
  "arti-client",
@@ -8782,9 +8777,9 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "crossbeam-channel",
  "document-features",
  "dynosaur",
+ "flume",
  "fs-mistrust",
  "futures-util",
  "getset",
@@ -8844,9 +8839,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b99abb0e534b72705f49cb43d5f1a448844b49b9c48590f87888cb84ce6d29"
+version = "0.21.1"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "bip32",
  "bitflags 2.11.0",
@@ -8892,8 +8886,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "corez",
  "hex",
@@ -8903,8 +8896,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "bech32 0.11.1",
  "bip32",
@@ -8947,8 +8939,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8979,8 +8970,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -9002,8 +8992,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "corez",
  "document-features",
@@ -9044,8 +9033,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "bip32",
  "bs58",
@@ -9139,8 +9127,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fef061351aa99792deb8f62b00426863a317ca2cb124c9de85550e3ef0f0f2f"
+source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,19 @@ tui = [
     "dep:tokio-util",
     "dep:tui-logger",
 ]
+
+# Track librustzcash main (TZE removal merged) until the next crates.io release.
+[patch.crates-io]
+equihash = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }

--- a/src/commands/wallet/sync.rs
+++ b/src/commands/wallet/sync.rs
@@ -683,6 +683,11 @@ async fn refresh_utxos<P: Parameters>(
                         Script(script::Code(reply.script)),
                     ),
                     Some(BlockHeight::from(u32::try_from(reply.height)?)),
+                    // A UTXO fetched from lightwalletd carries no wallet-account
+                    // context; the wallet associates it on store.
+                    None,
+                    None,
+                    None,
                 )
                 .ok_or(anyhow!(
                     "Received UTXO that doesn't correspond to a valid P2PKH or P2SH address"

--- a/src/helpers/pczt/create_manual.rs
+++ b/src/helpers/pczt/create_manual.rs
@@ -98,7 +98,7 @@ pub(crate) fn handle_recipient<C, T>(
 }
 
 pub(crate) fn add_inputs<P: consensus::Parameters, U: sapling::builder::ProverProgress>(
-    builder: &mut Builder<'_, P, U>,
+    builder: &mut Builder<P, U>,
     transparent_inputs: Vec<TransparentInputInfo>,
 ) -> anyhow::Result<()> {
     for input in transparent_inputs.into_iter() {
@@ -108,7 +108,7 @@ pub(crate) fn add_inputs<P: consensus::Parameters, U: sapling::builder::ProverPr
 }
 
 pub(crate) fn add_recipient<P: consensus::Parameters, U: sapling::builder::ProverProgress>(
-    builder: &mut Builder<'_, P, U>,
+    builder: &mut Builder<P, U>,
     recipient: Address,
     value: Zatoshis,
     memo: Option<MemoBytes>,

--- a/src/ui/proposal.rs
+++ b/src/ui/proposal.rs
@@ -77,7 +77,7 @@ fn print_payments(request: &TransactionRequest, payment_pools: &BTreeMap<usize, 
     }
 }
 
-fn print_transparent_inputs<P: Parameters>(inputs: &[WalletTransparentOutput], params: &P) {
+fn print_transparent_inputs<P: Parameters, A>(inputs: &[WalletTransparentOutput<A>], params: &P) {
     if inputs.is_empty() {
         return;
     }


### PR DESCRIPTION
## Summary

`zcash-devtool` tracks the in-development zcash crates, so this updates it to librustzcash `main` at `08334eb` (the commit at which TZE support was removed), via `[patch.crates-io]` git pins, until the next crates.io release.

Closes #175.

## Changes

- **`[patch.crates-io]`** pins all the librustzcash workspace crates devtool depends on to `08334eb`; `Cargo.lock` is updated accordingly (e.g. `zcash_client_sqlite` resolves to the git `0.21.1`).
- **API adaptations:**
  - `transaction::builder::Builder` lost its `'a` lifetime parameter (it was only there for TZE), so the manual-PCZT helpers take `&mut Builder<P, U>`.
  - `WalletTransparentOutput` is now generic over the account id: `print_transparent_inputs` is generic over the (display-only) account type, and `WalletTransparentOutput::from_parts` takes the new `recipient_account` / `recipient_key_scope` / `funding_account` arguments (all `None` for UTXOs fetched from lightwalletd, whose account context the wallet assigns on store).

## Verification

- `cargo clippy --all-targets -- -D warnings` (default)
- `cargo build --all-features`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

The `[patch.crates-io]` git pins are a stopgap; they should be replaced with a normal crates.io dependency bump once librustzcash publishes the next release containing these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
