### PR TITLE
ci: set explicit GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI checks
 
 on: [push, pull_request]
 
+# Restrict the default GITHUB_TOKEN to read-only; jobs that need more opt in below.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build on ${{ matrix.os }}
@@ -48,6 +52,10 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    # auguwu/clippy-action writes clippy results as check runs.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Clippy


### PR DESCRIPTION
Addresses the CodeQL "workflow does not contain permissions" finding: default the workflow's GITHUB_TOKEN to `contents: read`, and grant the Clippy job `checks: write` (auguwu/clippy-action posts its results as check runs).