### PR TITLE
Add wallet restore-mnemonic command

### DIFF
--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -18,6 +18,7 @@ pub(crate) mod list_unspent;
 pub(crate) mod pay;
 pub(crate) mod propose;
 pub(crate) mod reset;
+pub(crate) mod restore_mnemonic;
 pub(crate) mod send;
 pub(crate) mod shield;
 pub(crate) mod sync;
@@ -31,6 +32,9 @@ pub(crate) enum Command {
 
     /// Initialise a new view-only light wallet
     InitFvk(init_fvk::Command),
+
+    /// Restore a wallet from an existing mnemonic phrase
+    RestoreMnemonic(restore_mnemonic::Command),
 
     /// Decrypt and display the wallet's mnemonic recovery phrase, if any.
     DisplayMnemonic(display_mnemonic::Command),

--- a/src/commands/wallet/restore_mnemonic.rs
+++ b/src/commands/wallet/restore_mnemonic.rs
@@ -1,0 +1,171 @@
+use age::secrecy::ExposeSecret;
+use bip0039::{English, Mnemonic};
+use clap::Args;
+use secrecy::{ExposeSecret as _, SecretString, SecretVec, Zeroize};
+use tokio::io::AsyncWriteExt;
+
+use zcash_client_backend::proto::service;
+use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
+
+use crate::{config::WalletConfig, data::Network, remote::ConnectionArgs};
+
+// Options accepted for the `restore-mnemonic` command
+#[derive(Debug, Args)]
+pub(crate) struct Command {
+    /// A name for the account
+    #[arg(long)]
+    name: String,
+
+    /// age identity file to encrypt the mnemonic phrase to (generated if it doesn't exist)
+    #[arg(short, long)]
+    identity: String,
+
+    /// The wallet's birthday. Defaults to the network's Sapling activation height, so the
+    /// wallet scans the entire history it could possibly have received funds in.
+    #[arg(long)]
+    birthday: Option<u32>,
+
+    /// The network the wallet will be used with: \"test\", \"main\", or \"regtest\"
+    /// (requires the `regtest_support` feature). Default is \"test\".
+    #[arg(short, long)]
+    #[arg(value_parser = Network::parse)]
+    network: Network,
+
+    /// Required for `-n regtest`: a TOML file giving the validator's
+    /// activation height per network upgrade (keys: overwinter, sapling,
+    /// blossom, heartwood, canopy, nu5, nu6, nu6_1, nu6_2; a missing key
+    /// means the upgrade is inactive). The heights are persisted in the
+    /// wallet config so later commands agree. Rejected for main/test.
+    #[cfg(feature = "regtest_support")]
+    #[arg(long)]
+    activation_heights: Option<std::path::PathBuf>,
+
+    #[command(flatten)]
+    connection: ConnectionArgs,
+}
+
+impl Command {
+    pub(crate) async fn run(self, wallet_dir: Option<String>) -> Result<(), anyhow::Error> {
+        let opts = self;
+
+        // Regtest requires explicit activation heights (persisted below so
+        // later commands agree); they are rejected for main/test.
+        #[cfg(feature = "regtest_support")]
+        let params = match opts.network {
+            Network::Regtest(_) => {
+                let path = opts.activation_heights.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("`-n regtest` requires --activation-heights <file>")
+                })?;
+                Network::Regtest(crate::data::load_activation_heights(path)?)
+            }
+            other => {
+                if opts.activation_heights.is_some() {
+                    return Err(anyhow::anyhow!(
+                        "--activation-heights is only valid with `-n regtest`"
+                    ));
+                }
+                other
+            }
+        };
+        #[cfg(not(feature = "regtest_support"))]
+        let params = opts.network;
+
+        let mut client = opts.connection.connect(params, wallet_dir.as_ref()).await?;
+
+        // Get the current chain height (for the recover-until height).
+        let chain_tip: u32 = client
+            .get_latest_block(service::ChainSpec::default())
+            .await?
+            .into_inner()
+            .height
+            .try_into()
+            .expect("block heights must fit into u32");
+
+        let recipients = if tokio::fs::try_exists(&opts.identity).await? {
+            age::IdentityFile::from_file(opts.identity)?.to_recipients()?
+        } else {
+            eprintln!("Generating a new age identity to encrypt the mnemonic phrase");
+            let identity = age::x25519::Identity::generate();
+            let recipient = identity.to_public();
+
+            // Write it to the provided path so we have it for next time.
+            let mut f = tokio::fs::File::create_new(opts.identity).await?;
+            f.write_all(
+                format!(
+                    "# created: {}\n",
+                    chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+                )
+                .as_bytes(),
+            )
+            .await?;
+            f.write_all(format!("# public key: {recipient}\n").as_bytes())
+                .await?;
+            f.write_all(format!("{}\n", identity.to_string().expose_secret()).as_bytes())
+                .await?;
+            f.flush().await?;
+
+            vec![Box::new(recipient) as _]
+        };
+
+        // Read the mnemonic phrase to restore from. `rpassword` requires a
+        // controlling terminal (it prompts and reads via /dev/tty, failing
+        // with ENXIO when there is none), so when stdin is not a terminal —
+        // automation piping the phrase in — read a line from stdin instead.
+        let phrase = if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+            SecretString::new(rpassword::prompt_password("Enter mnemonic to restore:")?)
+        } else {
+            let mut line = String::new();
+            std::io::BufRead::read_line(&mut std::io::stdin().lock(), &mut line)?;
+            let phrase = SecretString::new(line.trim().to_string());
+            line.zeroize();
+            phrase
+        };
+        if phrase.expose_secret().is_empty() {
+            return Err(anyhow::anyhow!(
+                "A mnemonic phrase is required to restore a wallet"
+            ));
+        }
+        let mnemonic = <Mnemonic<English>>::from_phrase(phrase.expose_secret())?;
+
+        // Default to the network's Sapling activation height, so a restored
+        // wallet scans for all funds it could possibly have received, unless
+        // the caller knows (and provides) a more recent birthday.
+        let birthday_height = opts.birthday.map(Into::into).unwrap_or_else(|| {
+            params
+                .activation_height(NetworkUpgrade::Sapling)
+                .expect("Sapling activation height is known")
+        });
+
+        let birthday = super::init::Command::get_wallet_birthday(
+            client,
+            birthday_height,
+            Some(chain_tip.into()),
+        )
+        .await?;
+
+        // Save the wallet keys to disk.
+        WalletConfig::init_with_mnemonic(
+            wallet_dir.as_ref(),
+            recipients.iter().map(|r| r.as_ref() as _),
+            &mnemonic,
+            birthday.height(),
+            params,
+        )?;
+
+        let seed = {
+            let mut seed = mnemonic.to_seed("");
+            let secret = seed.to_vec();
+            seed.zeroize();
+            SecretVec::new(secret)
+        };
+
+        super::init::Command::init_dbs(
+            params,
+            wallet_dir.as_ref(),
+            &opts.name,
+            &seed,
+            birthday,
+            None,
+        )
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,9 @@ fn main() -> Result<(), anyhow::Error> {
             }) => match command {
                 commands::wallet::Command::Init(command) => command.run(wallet_dir).await,
                 commands::wallet::Command::InitFvk(command) => command.run(wallet_dir).await,
+                commands::wallet::Command::RestoreMnemonic(command) => {
+                    command.run(wallet_dir).await
+                }
                 commands::wallet::Command::DisplayMnemonic(command) => command.run(wallet_dir),
                 commands::wallet::Command::Reset(command) => command.run(wallet_dir).await,
                 commands::wallet::Command::ImportUfvk(command) => command.run(wallet_dir).await,


### PR DESCRIPTION
## Summary

- Adds `wallet restore-mnemonic`, a dedicated command for restoring a wallet from an existing mnemonic phrase, mirroring `init`'s network/connection/identity flags.
- Unlike `init` (which treats a pasted phrase as an optional alternative to generating a new one), this command requires a non-empty phrase — an empty entry is an error, not a fallback to wallet generation.
- When `--birthday` is omitted, defaults to the network's Sapling activation height (instead of `init`'s `chain_tip - 100`), so a restored wallet scans its entire possible history by default. `recover_until` is always set to the current chain tip.

Closes #179

## Test plan

- [x] `cargo build` (default features and `--features regtest_support`)
- [x] `cargo clippy --all-features`
- [x] `cargo fmt --check`
- [x] Manual end-to-end run against `testnet.zec.rocks:443` with a known test mnemonic and an explicit `--birthday`: wallet config persisted the correct birthday and encrypted mnemonic, and `wallet list-accounts` showed the restored account with the expected seed fingerprint.
- [x] Confirmed the default (no `--birthday`) path correctly requests the Sapling activation height's tree state from the server (a separate testnet server limitation pruning very old history surfaced as `GetTreeState` error — pre-existing behavior shared with `init`/`init-fvk`, not introduced by this change).