### PR TITLE
Make Tor connection opt-in; default to a direct connection

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -235,8 +235,8 @@ pub(crate) enum ConnectionMode {
 /// Parse a connection mode from a string.
 ///
 /// Supported formats:
-/// - `direct` - Direct TCP connection
-/// - `tor` - Use the built-in Tor client (default)
+/// - `direct` - Direct TCP connection (default)
+/// - `tor` - Use the built-in Tor client (opt-in)
 /// - `socks5://<host>:<port>` - Route through a SOCKS5 proxy
 fn parse_connection_mode(s: &str) -> Result<ConnectionMode, String> {
     match s {
@@ -262,8 +262,10 @@ pub(crate) struct ConnectionArgs {
     #[arg(short, long, default_value = "zecrocks", value_parser = Servers::parse)]
     pub(crate) server: Servers,
 
-    /// Connection mode: "direct", "tor" (default), or "socks5://<host>:<port>"
-    #[arg(long, default_value = "tor", value_parser = parse_connection_mode)]
+    /// Connection mode: "direct" (default), "tor", or "socks5://<host>:<port>".
+    /// Tor is opt-in: pass "--connection tor" to route over the built-in Tor
+    /// client.
+    #[arg(long, default_value = "direct", value_parser = parse_connection_mode)]
     pub(crate) connection: ConnectionMode,
 
     /// Deprecated: use --connection direct instead


### PR DESCRIPTION
## Problem

`--connection` defaulted to `tor`, so every networked command (e.g. `wallet init`, `wallet restore-mnemonic`, `sync`) routed through the built-in Tor client by default. Tor bootstraps fine, but the actual connection intermittently fails because arti resolves the lightwalletd hostname at the exit relay:

```
Error: gRPC-over-Tor error: Tonic error: transport error:
Tor error: tor: remote hostname lookup failure: Protocol error while launching a data stream
```

This failure lives in `arti`/`zcash_client_backend::tor` and is exit-relay/network dependent, so it isn't something we can reliably fix in this repo. The result was that the tool could fail out of the box through no fault of the user.

## Fix

Make Tor **opt-in**:

- Default `--connection` is now `direct`.
- Tor is available explicitly via `--connection tor`.
- Help text and doc comments updated to reflect that Tor is opt-in.

## Verification

Re-ran the previously failing flow (`wallet init` against `testnet.zec.rocks:443`) with the new default. It connects directly and completes wallet initialization (`data.sqlite`, `keys.toml` written). `--connection tor` still parses and routes over Tor for users who want it.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)