### PR TITLE
Handle wallet birthday at or below Sapling activation

### DIFF
--- a/src/commands/wallet/gen_account.rs
+++ b/src/commands/wallet/gen_account.rs
@@ -50,6 +50,7 @@ impl Command {
 
         let birthday = wallet::init::Command::get_wallet_birthday(
             client,
+            &params,
             chain_tip.saturating_sub(100).into(),
             None,
         )

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -6,10 +6,10 @@ use tokio::io::AsyncWriteExt;
 use tonic::transport::Channel;
 
 use zcash_client_backend::{
-    data_api::{AccountBirthday, WalletWrite},
+    data_api::{AccountBirthday, WalletWrite, chain::ChainState},
     proto::service::{self, compact_tx_streamer_client::CompactTxStreamerClient},
 };
-use zcash_protocol::consensus::{BlockHeight, Parameters};
+use zcash_protocol::consensus::{BlockHeight, NetworkUpgrade, Parameters};
 
 use crate::{
     config::WalletConfig,
@@ -143,6 +143,7 @@ impl Command {
 
         let birthday = Self::get_wallet_birthday(
             client,
+            &params,
             opts.birthday
                 .unwrap_or(chain_tip.saturating_sub(100))
                 .into(),
@@ -176,20 +177,52 @@ impl Command {
         )
     }
 
-    pub(crate) async fn get_wallet_birthday(
+    pub(crate) async fn get_wallet_birthday<P: Parameters>(
         mut client: CompactTxStreamerClient<Channel>,
+        params: &P,
         birthday_height: BlockHeight,
         recover_until: Option<BlockHeight>,
     ) -> Result<AccountBirthday, anyhow::Error> {
-        // Fetch the tree state corresponding to the last block prior to the wallet's
-        // birthday height. NOTE: THIS APPROACH LEAKS THE BIRTHDAY TO THE SERVER!
-        let request = service::BlockId {
-            height: u64::from(birthday_height).saturating_sub(1),
-            ..Default::default()
+        // A shielded wallet's birthday cannot meaningfully precede Sapling
+        // activation: there is no note commitment tree before then, and
+        // lightwalletd rejects `GetTreeState` for any height below it.
+        let sapling_activation = params
+            .activation_height(NetworkUpgrade::Sapling)
+            .expect("Sapling activation height is known");
+        let birthday_height = birthday_height.max(sapling_activation);
+
+        // The birthday is defined by the chain state (note commitment tree
+        // frontiers and block hash) as of the block *prior* to the birthday
+        // height.
+        let birthday = if birthday_height == sapling_activation {
+            // Edge case: the block prior to the birthday is the last pre-Sapling
+            // block, whose note commitment trees are empty and whose tree state
+            // the server cannot serve (`GetTreeState` below Sapling activation
+            // is rejected). Construct an empty chain state directly, taking the
+            // prior block's hash from the birthday block's `prev_hash` so block
+            // scanning can still verify chain continuity.
+            let birthday_block = client
+                .get_block(service::BlockId {
+                    height: u64::from(birthday_height),
+                    ..Default::default()
+                })
+                .await?
+                .into_inner();
+            AccountBirthday::from_parts(
+                ChainState::empty(birthday_height - 1, birthday_block.prev_hash()),
+                recover_until,
+            )
+        } else {
+            // Fetch the tree state corresponding to the last block prior to the
+            // wallet's birthday height. NOTE: THIS APPROACH LEAKS THE BIRTHDAY
+            // TO THE SERVER!
+            let request = service::BlockId {
+                height: u64::from(birthday_height) - 1,
+                ..Default::default()
+            };
+            let treestate = client.get_tree_state(request).await?.into_inner();
+            AccountBirthday::from_treestate(treestate, recover_until).map_err(error::Error::from)?
         };
-        let treestate = client.get_tree_state(request).await?.into_inner();
-        let birthday = AccountBirthday::from_treestate(treestate, recover_until)
-            .map_err(error::Error::from)?;
 
         Ok(birthday)
     }

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -188,7 +188,9 @@ impl Command {
         // lightwalletd rejects `GetTreeState` for any height below it.
         let sapling_activation = params
             .activation_height(NetworkUpgrade::Sapling)
-            .ok_or_else(|| anyhow::anyhow!("Sapling activation height is not set for this network"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!("Sapling activation height is not set for this network")
+            })?;
         let birthday_height = birthday_height.max(sapling_activation);
 
         // The birthday is defined by the chain state (note commitment tree
@@ -209,7 +211,10 @@ impl Command {
                 .await?
                 .into_inner();
             AccountBirthday::from_parts(
-                ChainState::empty(birthday_height.saturating_sub(1), birthday_block.prev_hash()),
+                ChainState::empty(
+                    birthday_height.saturating_sub(1),
+                    birthday_block.prev_hash(),
+                ),
                 recover_until,
             )
         } else {

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -209,7 +209,7 @@ impl Command {
                 .await?
                 .into_inner();
             AccountBirthday::from_parts(
-                ChainState::empty(birthday_height - 1, birthday_block.prev_hash()),
+                ChainState::empty(birthday_height.saturating_sub(1), birthday_block.prev_hash()),
                 recover_until,
             )
         } else {

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -188,7 +188,7 @@ impl Command {
         // lightwalletd rejects `GetTreeState` for any height below it.
         let sapling_activation = params
             .activation_height(NetworkUpgrade::Sapling)
-            .expect("Sapling activation height is known");
+            .ok_or_else(|| anyhow::anyhow!("Sapling activation height is not set for this network"))?;
         let birthday_height = birthday_height.max(sapling_activation);
 
         // The birthday is defined by the chain state (note commitment tree

--- a/src/commands/wallet/init_fvk.rs
+++ b/src/commands/wallet/init_fvk.rs
@@ -94,6 +94,7 @@ impl Command {
 
         let birthday = super::init::Command::get_wallet_birthday(
             client,
+            &network,
             opts.birthday
                 .unwrap_or(chain_tip.saturating_sub(100))
                 .into(),

--- a/src/commands/wallet/reset.rs
+++ b/src/commands/wallet/reset.rs
@@ -59,9 +59,13 @@ impl Command {
             )
         };
 
-        let birthday =
-            super::init::Command::get_wallet_birthday(client, config.birthday(), Some(chain_tip))
-                .await?;
+        let birthday = super::init::Command::get_wallet_birthday(
+            client,
+            &params,
+            config.birthday(),
+            Some(chain_tip),
+        )
+        .await?;
 
         // Erase the wallet state (excluding key material).
         erase_wallet_state(wallet_dir.as_ref()).await;

--- a/src/commands/wallet/restore_mnemonic.rs
+++ b/src/commands/wallet/restore_mnemonic.rs
@@ -138,6 +138,7 @@ impl Command {
 
         let birthday = super::init::Command::get_wallet_birthday(
             client,
+            &params,
             birthday_height,
             Some(chain_tip.into()),
         )


### PR DESCRIPTION
## Summary

Fixes `wallet restore-mnemonic` failing when no `--birthday` is provided, which produced:

```
Error: code: 'Client specified an invalid argument', message: "GetTreeState: z_gettreestate did not return treestate"
```

## Cause

With no `--birthday`, the birthday defaults to the network's Sapling activation height (testnet 280000). `get_wallet_birthday` then requested the treestate for the block *prior* to the birthday (`birthday_height - 1` = 279999), which is below Sapling activation. lightwalletd rejects `GetTreeState` below Sapling activation, so the default restore path always failed.

## Changes

- `get_wallet_birthday` now takes the network `params` and:
  - clamps the birthday to `max(birthday, sapling_activation)` — a shielded wallet cannot be born before Sapling;
  - when the birthday equals Sapling activation, constructs an empty `ChainState` via `AccountBirthday::from_parts` / `ChainState::empty`, taking the prior block's hash from the birthday block's `prev_hash()` (fetched with `GetBlock`) so block-scan continuity still validates, instead of requesting an unservable pre-Sapling treestate;
  - otherwise the original `GetTreeState` path is unchanged.
- Updated all call sites to pass the network parameters: `init`, `restore_mnemonic`, `reset`, `init_fvk`, `gen_account`.

## Testing

- `cargo build` and `cargo clippy` clean.
- Verified live against `testnet.zec.rocks`: `restore-mnemonic` with no `--birthday` now succeeds and creates the account at birthday height 280000 (Sapling activation), where it previously errored.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)