### PR TITLE
Show amounts with the network's currency (ZEC/TAZ/REG)

### DIFF
--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -200,10 +200,12 @@ fn inspect_zip321(request: TransactionRequest) {
         match payment.amount() {
             Some(amount) => {
                 let zats = amount.into_u64();
+                // A ZIP 321 payment request is network-agnostic, so default the
+                // ticker to mainnet's (ZEC) for display.
                 eprintln!(
-                    "   - Amount: {} zatoshis ({} ZEC)",
+                    "   - Amount: {} zatoshis ({})",
                     zats,
-                    format_zec(amount)
+                    format_zec(amount, NetworkType::Main)
                 );
             }
             None => eprintln!("   - Amount: not specified"),

--- a/src/commands/wallet/balance.rs
+++ b/src/commands/wallet/balance.rs
@@ -10,6 +10,7 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::WalletDb;
 use zcash_keys::keys::UnifiedAddressRequest;
+use zcash_protocol::consensus::{NetworkType, Parameters};
 use zcash_protocol::value::{COIN, Zatoshis};
 
 use crate::{
@@ -120,19 +121,20 @@ impl Command {
                     (*progress.numerator() as f64) * 100f64 / (*progress.denominator() as f64)
                 );
             }
-            println!("    Balance: {}", printer.format(balance.total()));
+            let net = params.network_type();
+            println!("    Balance: {}", printer.format(balance.total(), net));
             println!(
                 "     Sapling Spendable: {}",
-                printer.format(balance.sapling_balance().spendable_value()),
+                printer.format(balance.sapling_balance().spendable_value(), net),
             );
             println!(
                 "     Orchard Spendable: {}",
-                printer.format(balance.orchard_balance().spendable_value()),
+                printer.format(balance.orchard_balance().spendable_value(), net),
             );
             #[cfg(feature = "transparent-inputs")]
             println!(
                 "  Unshielded Spendable: {}",
-                printer.format(balance.unshielded_balance().spendable_value()),
+                printer.format(balance.unshielded_balance().spendable_value(), net),
             );
         } else {
             println!("Insufficient information to build a wallet summary.");
@@ -163,18 +165,18 @@ impl ValuePrinter {
         }
     }
 
-    fn format(&self, value: Zatoshis) -> String {
+    fn format(&self, value: Zatoshis, network: NetworkType) -> String {
         match self {
             ValuePrinter::WithConversion { currency, rate } => {
                 format!(
                     "{} ({}{:.2})",
-                    format_zec(value),
+                    format_zec(value, network),
                     currency.symbol(),
                     rate * Decimal::from_u64(value.into_u64()).unwrap()
                         / Decimal::from_u64(COIN).unwrap(),
                 )
             }
-            ValuePrinter::ZecOnly => format_zec(value),
+            ValuePrinter::ZecOnly => format_zec(value, network),
         }
     }
 }

--- a/src/commands/wallet/list_tx.rs
+++ b/src/commands/wallet/list_tx.rs
@@ -6,12 +6,16 @@ use uuid::Uuid;
 
 use zcash_protocol::{
     PoolType, TxId,
-    consensus::BlockHeight,
+    consensus::{BlockHeight, NetworkType, Parameters},
     memo::{Memo, MemoBytes},
     value::{ZatBalance, Zatoshis},
 };
 
-use crate::{data::get_db_paths, ui::format_zec};
+use crate::{
+    config::get_wallet_network,
+    data::get_db_paths,
+    ui::{format_zec, ticker},
+};
 
 // Options accepted for the `list-tx` command
 #[derive(Debug, Args)]
@@ -50,6 +54,7 @@ impl ListMode {
 
 impl Command {
     pub(crate) fn run(self, wallet_dir: Option<String>) -> anyhow::Result<()> {
+        let net = get_wallet_network(wallet_dir.as_ref())?.network_type();
         let (_, db_data) = get_db_paths(wallet_dir);
         let mode = self
             .mode
@@ -166,7 +171,7 @@ impl Command {
                     "mined_height": tx.mined_height.map(u32::from),
                 }));
             } else {
-                tx.print(mode)?;
+                tx.print(mode, net)?;
             }
         }
 
@@ -227,11 +232,11 @@ impl WalletTxOutput {
         })
     }
 
-    fn print_text(&self) {
+    fn print_text(&self, net: NetworkType) {
         println!("  Output {} ({})", self.output_index, self.pool);
         println!(
             "    Value: {}{}",
-            format_zec(self.value),
+            format_zec(self.value, net),
             if self.is_change {
                 " (Change)"
             } else if self.from_account.is_some() && self.to_account.is_some() {
@@ -265,7 +270,7 @@ impl WalletTxOutput {
         }
     }
 
-    fn print_csv(&self, context: &WalletTx) -> Result<(), anyhow::Error> {
+    fn print_csv(&self, context: &WalletTx, net: NetworkType) -> Result<(), anyhow::Error> {
         if self.is_change {
             //neither send nor receive, skip
             return Ok(());
@@ -290,8 +295,8 @@ impl WalletTxOutput {
                 .map(time::OffsetDateTime::from_unix_timestamp)
                 .transpose()?
                 .map_or(Ok("".to_string()), |t| t.format(format))?;
-            let symbol = "ZEC";
-            let volume = format_zec(self.value);
+            let symbol = ticker(net);
+            let volume = format_zec(self.value, net);
             let currency = "USD";
             let (account_id, account_name) = self
                 .to_account
@@ -303,8 +308,11 @@ impl WalletTxOutput {
                 .map_or("".to_string(), |n| format!(" ({n})"));
             let total = "";
             let price = "";
-            let fee = context.fee_paid.map(format_zec).unwrap_or("".to_string());
-            let fee_currency = "ZEC";
+            let fee = context
+                .fee_paid
+                .map(|f| format_zec(f, net))
+                .unwrap_or("".to_string());
+            let fee_currency = ticker(net);
             let memo = self.memo.as_ref().map_or("".to_string(), |m| match m {
                 Memo::Empty => "".to_string(),
                 Memo::Text(text_memo) => text_memo.to_string(),
@@ -367,17 +375,17 @@ impl WalletTx {
         })
     }
 
-    fn print(&self, mode: ListMode) -> Result<(), anyhow::Error> {
+    fn print(&self, mode: ListMode, net: NetworkType) -> Result<(), anyhow::Error> {
         match mode {
             ListMode::Text => {
-                self.print_text();
+                self.print_text(net);
                 Ok(())
             }
-            ListMode::Csv => self.print_csv(),
+            ListMode::Csv => self.print_csv(net),
         }
     }
 
-    fn print_text(&self) {
+    fn print_text(&self, net: NetworkType) {
         let height_to_str = |height: Option<BlockHeight>, def: &str| {
             height.map(|h| h.to_string()).unwrap_or(def.to_owned())
         };
@@ -399,11 +407,14 @@ impl WalletTx {
                 height_to_str(self.expiry_height, "Unknown"),
             );
         }
-        println!("    Amount: {}", format_zec(self.account_balance_delta));
+        println!(
+            "    Amount: {}",
+            format_zec(self.account_balance_delta, net)
+        );
         println!(
             "  Fee paid: {}",
             self.fee_paid
-                .map(format_zec)
+                .map(|f| format_zec(f, net))
                 .as_deref()
                 .unwrap_or("Unknown"),
         );
@@ -412,13 +423,13 @@ impl WalletTx {
             self.sent_note_count, self.received_note_count, self.memo_count,
         );
         for output in &self.outputs {
-            output.print_text()
+            output.print_text(net)
         }
     }
 
-    fn print_csv(&self) -> Result<(), anyhow::Error> {
+    fn print_csv(&self, net: NetworkType) -> Result<(), anyhow::Error> {
         for output in &self.outputs {
-            output.print_csv(self)?;
+            output.print_csv(self, net)?;
         }
 
         Ok(())

--- a/src/commands/wallet/list_unspent.rs
+++ b/src/commands/wallet/list_unspent.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 use zcash_client_backend::data_api::{Account as _, InputSource, WalletRead};
 use zcash_client_sqlite::WalletDb;
 use zcash_protocol::ShieldedProtocol;
+use zcash_protocol::consensus::Parameters;
 
 use crate::{
     commands::select_account, config::get_wallet_network, data::get_db_paths, error, ui::format_zec,
@@ -37,11 +38,12 @@ impl Command {
             &[],
         )?;
 
+        let net = params.network_type();
         for note in notes.sapling() {
             println!(
                 "Sapling {}: {}",
                 note.internal_note_id(),
-                format_zec(note.note_value()?)
+                format_zec(note.note_value()?, net)
             );
         }
 
@@ -49,7 +51,7 @@ impl Command {
             println!(
                 "Orchard {}: {}",
                 note.internal_note_id(),
-                format_zec(note.note_value()?)
+                format_zec(note.note_value()?, net)
             );
         }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,22 @@
+use zcash_protocol::consensus::NetworkType;
 use zcash_protocol::value::ZatBalance;
 
 pub(crate) mod proposal;
 
 const COIN: u64 = 1_0000_0000;
 
-pub(crate) fn format_zec(value: impl TryInto<ZatBalance>) -> String {
+/// The display ticker for amounts on the given network, matching the
+/// zcashd/zebra convention: `ZEC` on mainnet, `TAZ` on testnet, `REG` on
+/// regtest.
+pub(crate) fn ticker(network: NetworkType) -> &'static str {
+    match network {
+        NetworkType::Main => "ZEC",
+        NetworkType::Test => "TAZ",
+        NetworkType::Regtest => "REG",
+    }
+}
+
+pub(crate) fn format_zec(value: impl TryInto<ZatBalance>, network: NetworkType) -> String {
     let value = i64::from(
         value
             .try_into()
@@ -19,5 +31,5 @@ pub(crate) fn format_zec(value: impl TryInto<ZatBalance>) -> String {
     } else {
         abs_zec as i64
     };
-    format!("{zec:3}.{frac:08} ZEC")
+    format!("{zec:3}.{frac:08} {}", ticker(network))
 }

--- a/src/ui/proposal.rs
+++ b/src/ui/proposal.rs
@@ -9,7 +9,7 @@ use zcash_client_backend::{
 };
 use zcash_protocol::{
     PoolType,
-    consensus::Parameters,
+    consensus::{NetworkType, Parameters},
     memo::{Memo, MemoBytes},
 };
 use zip321::TransactionRequest;
@@ -30,22 +30,32 @@ pub(crate) fn print_proposal<P: Parameters, FeeRuleT: Debug, NoteRef>(
     println!("  Fee rule: {:?}", proposal.fee_rule());
     let steps = proposal.steps();
     println!("  Steps ({}):", steps.len());
+    let net = params.network_type();
     for (i, step) in steps.iter().enumerate() {
-        print_step(i, step, params);
+        print_step(i, step, params, net);
     }
 }
 
-fn print_step<P: Parameters, NoteRef>(index: usize, step: &Step<NoteRef>, params: &P) {
+fn print_step<P: Parameters, NoteRef>(
+    index: usize,
+    step: &Step<NoteRef>,
+    params: &P,
+    net: NetworkType,
+) {
     println!("    Step {index}:");
     println!("      Shielding: {}", step.is_shielding());
-    print_payments(step.transaction_request(), step.payment_pools());
-    print_transparent_inputs(step.transparent_inputs(), params);
-    print_shielded_inputs(step.shielded_inputs());
+    print_payments(step.transaction_request(), step.payment_pools(), net);
+    print_transparent_inputs(step.transparent_inputs(), params, net);
+    print_shielded_inputs(step.shielded_inputs(), net);
     print_prior_step_inputs(step.prior_step_inputs());
-    print_balance(step.balance());
+    print_balance(step.balance(), net);
 }
 
-fn print_payments(request: &TransactionRequest, payment_pools: &BTreeMap<usize, PoolType>) {
+fn print_payments(
+    request: &TransactionRequest,
+    payment_pools: &BTreeMap<usize, PoolType>,
+    net: NetworkType,
+) {
     let payments = request.payments();
     println!("      Payments ({}):", payments.len());
     for (idx, payment) in payments {
@@ -58,7 +68,7 @@ fn print_payments(request: &TransactionRequest, payment_pools: &BTreeMap<usize, 
             "            Amount: {}",
             payment
                 .amount()
-                .map(format_zec)
+                .map(|v| format_zec(v, net))
                 .unwrap_or_else(|| "<unspecified>".to_owned()),
         );
         println!("            Pool: {pool}");
@@ -77,7 +87,11 @@ fn print_payments(request: &TransactionRequest, payment_pools: &BTreeMap<usize, 
     }
 }
 
-fn print_transparent_inputs<P: Parameters, A>(inputs: &[WalletTransparentOutput<A>], params: &P) {
+fn print_transparent_inputs<P: Parameters, A>(
+    inputs: &[WalletTransparentOutput<A>],
+    params: &P,
+    net: NetworkType,
+) {
     if inputs.is_empty() {
         return;
     }
@@ -88,13 +102,13 @@ fn print_transparent_inputs<P: Parameters, A>(inputs: &[WalletTransparentOutput<
             "        - {}:{}  {}  -> {}",
             outpoint.txid(),
             outpoint.n(),
-            format_zec(input.value()),
+            format_zec(input.value(), net),
             input.recipient_address().encode(params),
         );
     }
 }
 
-fn print_shielded_inputs<NoteRef>(inputs: Option<&ShieldedInputs<NoteRef>>) {
+fn print_shielded_inputs<NoteRef>(inputs: Option<&ShieldedInputs<NoteRef>>, net: NetworkType) {
     let Some(inputs) = inputs else {
         return;
     };
@@ -105,11 +119,11 @@ fn print_shielded_inputs<NoteRef>(inputs: Option<&ShieldedInputs<NoteRef>>) {
         u32::from(inputs.anchor_height()),
     );
     for received in notes.iter() {
-        print_received_note(received);
+        print_received_note(received, net);
     }
 }
 
-fn print_received_note<NoteRef>(received: &ReceivedNote<NoteRef, Note>) {
+fn print_received_note<NoteRef>(received: &ReceivedNote<NoteRef, Note>, net: NetworkType) {
     let pool = match received.note() {
         Note::Sapling(_) => "Sapling",
         Note::Orchard(_) => "Orchard",
@@ -118,7 +132,7 @@ fn print_received_note<NoteRef>(received: &ReceivedNote<NoteRef, Note>) {
         "        - {pool} {}:{}  {}",
         received.txid(),
         received.output_index(),
-        format_zec(received.note().value()),
+        format_zec(received.note().value(), net),
     );
 }
 
@@ -136,14 +150,14 @@ fn print_prior_step_inputs(refs: &[StepOutput]) {
     }
 }
 
-fn print_balance(balance: &TransactionBalance) {
+fn print_balance(balance: &TransactionBalance, net: NetworkType) {
     let changes = balance.proposed_change();
     println!("      Change outputs ({}):", changes.len());
     for change in changes {
         let mut line = format!(
             "        - {} {}",
             change.output_pool(),
-            format_zec(change.value()),
+            format_zec(change.value(), net),
         );
         if change.is_ephemeral() {
             line.push_str(" [ephemeral]");
@@ -153,7 +167,7 @@ fn print_balance(balance: &TransactionBalance) {
             print_memo(12, memo);
         }
     }
-    println!("      Fee: {}", format_zec(balance.fee_required()));
+    println!("      Fee: {}", format_zec(balance.fee_required(), net));
 }
 
 fn print_memo(indent: usize, memo: &MemoBytes) {


### PR DESCRIPTION
Amounts were always printed as "ZEC" regardless of network. This update denominates them with the network's currency unit, matching zcashd's strCurrencyUnits (chainparams.cpp): ZEC on mainnet, TAZ on testnet, REG on regtest.

balance, list-tx, and list-unspent commands now print the correct currency ticker. Inspecting a ZIP 321 payment request is network-agnostic so it defaults to ZEC.