### PR TITLE
Port pin-independent Ironwood groundwork from zecrocks/ironwood-valar

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# zcash-devtool
+
+A CLI for operating Zcash wallets and inspecting chain data, including against
+throwaway regtest chains whose consensus parameters the operator defines.
+
+## Language
+
+### Regtest consensus parameters
+
+**Activation Heights File**:
+The operator-authored TOML naming an activation height (or `"never"`) per
+network upgrade, required when creating a regtest wallet. The operator keeps it
+in revision control and in sync with the validator's own configuration by hand.
+_Avoid_: regtest config, node config (the validator never reads this file)
+
+**Wallet Config**:
+The per-wallet persisted record of a wallet's identity and, for regtest, a copy
+of its Activation Heights File taken at creation time, so every later command
+sees the same chain the wallet was created against.
+_Avoid_: keys file, wallet settings
+
+**Explicitly Inactive**:
+An upgrade whose key is written as `"never"` in an Activation Heights File or
+Wallet Config — a deliberate operator choice that the upgrade does not exist on
+this chain. Loads silently.
+_Avoid_: disabled, off
+
+**Implicitly Inactive**:
+An upgrade whose key is absent entirely. Treated as inactive, but warned about
+on load, because absence may only mean the file predates the tool's knowledge
+of that upgrade.
+_Avoid_: unset, missing (without qualification)
+
+**Fallback Heights**:
+The baked-in regtest heights used only by commands that take no Activation
+Heights File; they mirror the `zcash_local_net` wallet-funding validator
+fixture. Wallets created with an Activation Heights File never consult them.
+_Avoid_: default network, default heights
+
+**Height Drift**:
+Disagreement between a wallet's recorded activation heights and those of the
+validator it talks to. Drift makes the wallet derive a different consensus
+branch ID than the validator expects, so the validator rejects its
+transactions.
+_Avoid_: mismatch (without saying between what)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "age"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf640be7658959746f1f0f2faab798f6098a9436a8e18e148d18bc9875e13c4b"
+checksum = "a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5"
 dependencies = [
  "age-core",
  "base64 0.21.7",
@@ -47,7 +47,7 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust-embed",
  "scrypt",
  "sha2 0.10.9",
@@ -70,7 +70,7 @@ dependencies = [
  "hkdf",
  "io_tee",
  "nom 7.1.3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secrecy 0.10.3",
  "sha2 0.10.9",
  "tempfile",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "amplify_num"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bcb75a2982047f733547042fc3968c0f460dfcf7d90b90dea3b2744580e9ad"
+checksum = "afed304556696656d2d71495e1e5f2c4b524a3fb6eb0f2f3778ffc482a40b8a8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -257,9 +257,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -272,7 +272,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -283,9 +283,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arti-client"
@@ -307,7 +307,7 @@ dependencies = [
  "libc",
  "once_cell",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "thiserror 2.0.18",
@@ -353,9 +353,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -374,7 +374,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -386,7 +386,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -397,9 +397,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -415,7 +415,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -462,6 +462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,9 +478,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-scenechange"
@@ -509,18 +518,18 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -653,8 +662,8 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
+ "shlex 1.3.0",
+ "syn 2.0.118",
  "which 4.4.2",
 ]
 
@@ -666,7 +675,7 @@ checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
  "unicode-normalization",
  "zeroize",
@@ -732,24 +741,24 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -787,7 +796,7 @@ checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -829,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -840,15 +849,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -872,26 +881,26 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "by_address"
@@ -941,9 +950,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "caret"
@@ -983,14 +992,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1046,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1109,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1131,14 +1140,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1188,7 +1197,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block",
  "core-foundation 0.10.1",
  "core-graphics-types",
@@ -1209,9 +1218,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
 dependencies = [
  "castaway",
  "cfg-if 1.0.4",
@@ -1223,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -1236,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -1248,6 +1257,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-oid"
@@ -1329,7 +1344,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1360,15 +1375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "corez"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1451,6 +1457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,7 +1511,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "futures-core",
  "mio",
@@ -1589,7 +1601,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1656,7 +1668,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1670,7 +1682,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1692,7 +1704,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1703,14 +1715,14 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1764,15 +1776,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5f2b7218a51c827a11d22d1439b598121fac94bf9b99452e4afffe512d78c9"
 dependencies = [
  "heck",
- "indexmap 2.13.0",
- "itertools 0.14.0",
+ "indexmap 2.14.0",
+ "itertools 0.15.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "sha3",
- "strum 0.26.3",
- "syn 2.0.117",
+ "strum 0.27.2",
+ "syn 2.0.118",
  "void",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1825,7 +1848,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1884,13 +1907,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1922,22 +1945,22 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynosaur"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12303417f378f29ba12cb12fc78a9df0d8e16ccb1ad94abf04d48d96bdda532"
+checksum = "fdb33e6854ea615b65faf9c40d4ea9c4de9e9fa5d6772ad6ce57950a6da3957d"
 dependencies = [
  "dynosaur_derive",
 ]
 
 [[package]]
 name = "dynosaur_derive"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0713d5c1d52e774c5cd7bb8b043d7c0fc4f921abfb678556140bfbe6ab2364"
+checksum = "5ac0893f103ae7bf50181323d748d505f27b6255777c28b502030bdaf8749f4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2012,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -2057,7 +2080,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2069,7 +2092,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2099,7 +2122,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2115,7 +2138,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -2166,7 +2189,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2185,29 +2208,15 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -2250,13 +2259,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2400,6 +2408,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "frost-core"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core 0.6.4",
+ "serde",
+ "serdect",
+ "thiserror 2.0.18",
+ "visibility",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "fs-mistrust"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,7 +2529,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2538,7 +2581,7 @@ dependencies = [
  "g2poly",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2597,34 +2640,31 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2656,9 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2666,7 +2706,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2698,7 +2738,7 @@ dependencies = [
  "halo2_proofs",
  "lazy_static",
  "pasta_curves",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sinsemilla",
  "subtle",
  "uint",
@@ -2740,6 +2780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,12 +2820,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2841,9 +2910,9 @@ checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2886,9 +2955,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "humantime-serde"
@@ -2911,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2926,7 +2995,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3014,7 +3082,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unic-langid",
 ]
 
@@ -3028,7 +3096,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3054,12 +3122,6 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -3103,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "incrementalmerkletree"
@@ -3115,7 +3177,7 @@ checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
 ]
 
@@ -3142,12 +3204,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3163,20 +3225,20 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
 dependencies = [
  "libc",
 ]
@@ -3200,7 +3262,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3211,7 +3273,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3235,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8062b737e5389949f477d4760a2ebbff0c366f97798f2419b8d8f366363d3342"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -3303,6 +3365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,11 +3391,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if 1.0.4",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -3362,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -3372,11 +3444,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -3396,12 +3468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3409,15 +3475,15 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -3435,18 +3501,18 @@ dependencies = [
 
 [[package]]
 name = "liblzma"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+checksum = "45aec2360b3933207e27908049d8e4df4e476b58180afb1e56b2a4fb72efe4ba"
 dependencies = [
  "liblzma-sys",
 ]
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186"
+checksum = "a046c7f353ba30f810545151e04f63545833803f5b86ee3ddf1517247fe560a5"
 dependencies = [
  "cc",
  "libc",
@@ -3461,14 +3527,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -3511,9 +3574,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loop9"
@@ -3569,15 +3632,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3659,9 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -3736,10 +3799,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "nokhwa"
-version = "0.10.10"
+name = "no_std_io2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cae50786bfa1214ed441f98addbea51ca1b9aaa9e4bf5369cda36654b3efaa"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nokhwa"
+version = "0.10.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d63f10b450319a0ace7aa8e0e25477d1fdb345313a97e220e886175539a1dbb"
 dependencies = [
  "flume",
  "image",
@@ -3753,19 +3825,20 @@ dependencies = [
 
 [[package]]
 name = "nokhwa-bindings-linux"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd666aaa41d14357817bd9a981773a73c4d00b34d344cfc244e47ebd397b1ec"
+checksum = "bb67e22201a53322291740ca064b20eaaade7222ef0349f312d9b37b004e1984"
 dependencies = [
+ "libc",
  "nokhwa-core",
  "v4l",
 ]
 
 [[package]]
 name = "nokhwa-bindings-macos"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de78eb4a2d47a68f490899aa0516070d7a972f853ec2bb374ab53be0bd39b60f"
+checksum = "f70d3908ea68324e44a6b3a0f885aa59e433fb1f6678839d09e0df7d226fb42d"
 dependencies = [
  "block",
  "cocoa-foundation",
@@ -3780,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "nokhwa-bindings-windows"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899799275c93ef69bbe8cb888cf6f8249abe751cbc50be5299105022aec14a1c"
+checksum = "5be28886bad8abcec3655c1f24b965b4cb596a72b23164c910c54439ce55d2a4"
 dependencies = [
  "nokhwa-core",
  "once_cell",
@@ -3791,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "nokhwa-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109975552bbd690894f613bce3d408222911e317197c72b2e8b9a1912dc261ae"
+checksum = "b1cba20bebd3bd9ae22f9273ade5bbe49da3e047c8512b53fbaf8b4b9c80d496"
 dependencies = [
  "bytes",
  "image",
@@ -3844,7 +3917,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "inotify",
  "kqueue",
  "libc",
@@ -3861,7 +3934,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3884,9 +3957,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3903,7 +3976,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -3922,7 +3995,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3995,7 +4068,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4014,7 +4087,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4077,9 +4150,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
+version = "0.15.0-pre.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
+checksum = "d77752de9c2865ca4a0d962b201b473d60bbe438d53a964a8707ec4bd401d631"
 dependencies = [
  "aes",
  "bitvec",
@@ -4099,7 +4172,7 @@ dependencies = [
  "nonempty",
  "pasta_curves",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "reddsa",
  "serde",
@@ -4201,7 +4274,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -4227,7 +4300,7 @@ dependencies = [
  "ff",
  "group",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
  "subtle",
 ]
@@ -4258,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4311,7 +4384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4322,7 +4395,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4353,7 +4426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4376,7 +4449,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4389,7 +4462,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4412,22 +4485,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4435,12 +4508,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -4465,15 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -4509,7 +4570,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4551,6 +4612,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "serde",
 ]
 
@@ -4576,7 +4638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4595,7 +4657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
  "equivalent",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -4605,7 +4667,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -4627,7 +4689,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4641,21 +4703,21 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4666,10 +4728,10 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
@@ -4680,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4690,9 +4752,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -4703,28 +4765,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -4763,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -4796,9 +4858,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4823,9 +4885,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4834,9 +4896,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4887,7 +4949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4925,7 +4987,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -4967,7 +5029,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -4992,9 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -5021,19 +5083,20 @@ dependencies = [
 
 [[package]]
 name = "reddsa"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
+checksum = "4784b85c8bfd17b36b86e664e6e504ecdb586001086ee23749e4a633bbb84832"
 dependencies = [
  "blake2b_simd",
  "byteorder",
+ "frost-rerandomized",
  "group",
  "hex",
  "jubjub",
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -5055,16 +5118,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5095,14 +5149,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5123,9 +5177,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -5234,13 +5288,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5277,12 +5331,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5291,7 +5345,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -5321,7 +5375,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.117",
+ "syn 2.0.118",
  "walkdir",
 ]
 
@@ -5337,15 +5391,15 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -5360,9 +5414,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -5388,7 +5442,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5401,7 +5455,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -5410,9 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -5425,18 +5479,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5531,7 +5585,7 @@ dependencies = [
  "lazy_static",
  "memuse",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "redjubjub",
  "subtle",
@@ -5680,9 +5734,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -5721,7 +5775,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5736,9 +5790,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5758,9 +5812,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -5775,7 +5829,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -5793,7 +5847,17 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -5831,9 +5895,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest 0.10.7",
  "keccak",
@@ -5854,7 +5918,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -5876,6 +5940,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -5952,9 +6022,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -5987,15 +6057,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -6114,7 +6184,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6126,7 +6196,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6148,9 +6218,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6171,7 +6241,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6201,7 +6271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -6233,7 +6303,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6244,7 +6314,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6303,9 +6373,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -6339,9 +6409,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6355,13 +6425,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6376,9 +6446,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-socks"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
 dependencies = [
  "either",
  "futures-util",
@@ -6438,9 +6508,9 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -6467,9 +6537,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -6480,7 +6550,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -6490,23 +6560,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6517,9 +6587,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -6562,7 +6632,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6587,7 +6657,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
  "tonic-build",
 ]
@@ -6619,7 +6689,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "serde",
  "slab",
@@ -6652,7 +6722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79ba1b43f22fab2daee3e0c902f1455b3aed8e086b2d83d8c60b36523b173d25"
 dependencies = [
  "amplify",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "caret",
  "derive-deftly",
@@ -6660,7 +6730,7 @@ dependencies = [
  "educe",
  "itertools 0.14.0",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "thiserror 2.0.18",
  "tor-basic-utils",
@@ -6705,7 +6775,7 @@ dependencies = [
  "futures",
  "oneshot-fused-workaround",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "thiserror 2.0.18",
@@ -6760,7 +6830,7 @@ dependencies = [
  "once_cell",
  "oneshot-fused-workaround",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "retry-error",
  "safelog",
  "serde",
@@ -6919,7 +6989,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "paste",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rusqlite",
  "safelog",
  "scopeguard",
@@ -6999,7 +7069,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "pin-project",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "strum 0.27.2",
@@ -7035,7 +7105,7 @@ dependencies = [
  "humantime",
  "itertools 0.14.0",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "signature",
@@ -7060,7 +7130,7 @@ dependencies = [
  "derive_more",
  "downcast-rs",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rsa",
  "signature",
  "ssh-key",
@@ -7091,7 +7161,7 @@ dependencies = [
  "humantime",
  "inventory",
  "itertools 0.14.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "safelog",
  "serde",
  "signature",
@@ -7157,7 +7227,7 @@ dependencies = [
  "educe",
  "getrandom 0.3.4",
  "hex",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
  "rand_core 0.9.5",
@@ -7231,13 +7301,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "638b4e6507e3786488859d3c463fa73addbad4f788806c6972603727e527672e"
 dependencies = [
  "async-trait",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "derive_more",
  "futures",
  "humantime",
  "itertools 0.14.0",
  "num_enum",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.18",
@@ -7260,7 +7330,7 @@ checksum = "1dbc32d89e7ea2e2799168d0c453061647a727e39fc66f52e1bcb4c38c8dc433"
 dependencies = [
  "amplify",
  "base64ct",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cipher",
  "derive-deftly",
  "derive_builder_fork_arti",
@@ -7352,7 +7422,7 @@ dependencies = [
  "oneshot-fused-workaround",
  "pin-project",
  "postage",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_core 0.9.5",
  "safelog",
  "slotmap-careful",
@@ -7405,7 +7475,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54cc2b365bf5881b4380059e0636cc40e1fa18a1b3b050f78ce322c95139d467"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "tor-basic-utils",
  "tor-linkspec",
@@ -7510,7 +7580,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -7552,7 +7622,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7612,7 +7682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7623,7 +7693,7 @@ checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7655,7 +7725,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -7670,9 +7740,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uint"
@@ -7737,9 +7807,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -7813,11 +7883,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -7880,7 +7950,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7975,36 +8045,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasix"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332"
+checksum = "ae86f02046da16a333a9129d31451423e1657737ecdafed4193838a5f54c5cfe"
 dependencies = [
  "wasi",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -8016,9 +8077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8026,58 +8087,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
 ]
 
 [[package]]
@@ -8088,9 +8115,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8098,9 +8125,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8125,9 +8152,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
 ]
@@ -8262,7 +8289,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8273,7 +8300,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8538,100 +8565,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wsl"
@@ -8705,7 +8650,7 @@ dependencies = [
  "pczt",
  "prost",
  "qrcode",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ratatui",
  "rayon",
  "ripemd 0.1.3",
@@ -8752,8 +8697,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+version = "0.13.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -8766,7 +8711,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.23.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "ambassador",
  "arti-client",
@@ -8799,7 +8744,7 @@ dependencies = [
  "postcard",
  "proptest",
  "prost",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
@@ -8823,7 +8768,7 @@ dependencies = [
  "tracing",
  "trait-variant",
  "webpki-roots",
- "which 8.0.2",
+ "which 8.0.4",
  "zcash_address",
  "zcash_encoding",
  "zcash_keys",
@@ -8840,10 +8785,10 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.21.1"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "bip32",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bs58",
  "byteorder",
  "document-features",
@@ -8855,7 +8800,7 @@ dependencies = [
  "nonempty",
  "orchard",
  "prost",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_distr",
  "regex",
@@ -8886,7 +8831,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "corez",
  "hex",
@@ -8895,8 +8840,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+version = "0.15.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "bech32 0.11.1",
  "bip32",
@@ -8938,8 +8883,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+version = "0.29.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -8969,8 +8914,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.28.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+version = "0.29.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -8991,8 +8936,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+version = "0.10.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "corez",
  "document-features",
@@ -9006,12 +8951,12 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ef9d04e0434a80b62ad06c5a610557be358ef60a98afa5dbc8ecaf19ad72e7"
+checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
@@ -9032,8 +8977,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+version = "0.9.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "bip32",
  "bs58",
@@ -9057,55 +9002,55 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "zerofrom",
@@ -9127,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.8.0"
-source = "git+https://github.com/zcash/librustzcash?rev=08334ebeddd15516385070296c6fdeb09c4620c3#08334ebeddd15516385070296c6fdeb09c4620c3"
+source = "git+https://github.com/zcash/librustzcash?rev=bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8#bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,21 +40,21 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = "1"
 
 # Zcash
-orchard = { version = "0.14", default-features = false }
+orchard = { version = "0.15.0-pre.1", default-features = false }
 pczt = "0.7"
 sapling = { package = "sapling-crypto", version = "0.7" }
-transparent = { package = "zcash_transparent", version = "0.8", features = ["test-dependencies"] }
-zcash_address = "0.12"
+transparent = { package = "zcash_transparent", version = "0.9.0-pre.0", features = ["test-dependencies"] }
+zcash_address = "0.13.0-pre.0"
 zcash_client_backend = { version = "0.23", features = ["lightwalletd-tonic-tls-webpki-roots", "orchard", "pczt", "tor", "unstable"] }
 # `transparent-inputs` is enabled unconditionally: `zcash_client_backend`'s `pczt`
 # feature (always on here) already forces `zcash_client_backend/transparent-inputs`,
 # so `zcash_client_sqlite` must match or its `WalletRead`/`WalletWrite` impls fail to
 # cover the trait's transparent methods.
 zcash_client_sqlite = { version = "0.21", features = ["transparent-inputs", "unstable", "orchard", "serde", "test-dependencies"] }
-zcash_keys = { version = "0.14", features = ["orchard", "unstable", "unstable-frost"] }
-zcash_primitives = "0.28"
-zcash_proofs = { version = "0.28", features = ["bundled-prover"] }
-zcash_protocol = { version = "0.9", features = ["local-consensus"] }
+zcash_keys = { version = "0.15.0-pre.0", features = ["orchard", "unstable", "unstable-frost"] }
+zcash_primitives = "0.29.0-pre.0"
+zcash_proofs = { version = "0.29.0-pre.0", features = ["bundled-prover"] }
+zcash_protocol = { version = "0.10.0-pre.0", features = ["local-consensus"] }
 zcash_script = "0.4"
 zip32 = "0.2"
 zip321 = "0.8"
@@ -124,18 +124,18 @@ tui = [
     "dep:tui-logger",
 ]
 
-# Track librustzcash main (TZE removal merged) until the next crates.io release.
+# Track librustzcash main (NU6.3 support) until the next crates.io release.
 [patch.crates-io]
-equihash = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zip321 = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-pczt = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "08334ebeddd15516385070296c6fdeb09c4620c3" }
+equihash = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zip321 = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+pczt = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "bd1bc3fbe6b9168c9654db2b3a7fdc5e7b1c15f8" }

--- a/doc/ironwood.md
+++ b/doc/ironwood.md
@@ -1,8 +1,9 @@
 # Ironwood (NU6.3 / V6) support
 
 `zcash-devtool` tracks the **Zcash Ironwood** upgrade so it can create, inspect,
-and exercise **V6 (Ironwood) transactions** end to end — talking to
-`lightwalletd` over gRPC as the *funder* in a local harness, and as a general
+and exercise **V6 (Ironwood) transactions** end to end — acting as the *funder*
+in a local harness, speaking the lightwalletd gRPC interface
+(`CompactTxStreamer`) to an indexer (`zainod` in our stack), and as a general
 inspection/PCZT tool.
 
 Ironwood is the **NU6.3** network upgrade. In `librustzcash` the network
@@ -50,7 +51,7 @@ network's activation schedule decides this:
 | Network | NU6.3 (Ironwood) activation | Notes |
 |---|---|---|
 | **mainnet** | not yet scheduled (`None`) | V6 is inactive until NU6.3 is assigned a mainnet height in a future `zcash_protocol` release. Nothing to configure here; the tool follows the schedule baked into `zcash_protocol`. |
-| **testnet** | height **4,134,000** | Scheduled in `zcash_protocol`. Point the wallet at a testnet `lightwalletd` (`-n test -s zecrocks`) and it produces V6 transactions once the tip passes 4,134,000. |
+| **testnet** | height **4,134,000** | Scheduled in `zcash_protocol`. Point the wallet at a testnet indexer (`-n test -s zecrocks`) and it produces V6 transactions once the tip passes 4,134,000. |
 | **regtest** | **operator-chosen** | Set via the `--activation-heights` file at `init` (see below). This is how you get a chain where Ironwood is active from the start for local testing. |
 
 Because activation is driven entirely by the network parameters, **testnet works
@@ -86,7 +87,7 @@ about on every load, since absence may just mean the file predates the tool's
 knowledge of that upgrade. `nu6_3` is the Ironwood key:
 
 ```toml
-# regtest-heights.toml — must match the validator (zebra) and lightwalletd.
+# regtest-heights.toml — must match the validator (zebra) and zainod.
 overwinter = 1
 sapling    = 1
 blossom    = 1
@@ -99,7 +100,7 @@ nu6_2      = 1
 nu6_3      = 1   # Ironwood / V6 active from height 1; write "never" to disable
 ```
 
-**3. Initialise the wallet against your local `lightwalletd`.** Regtest has no
+**3. Initialise the wallet against your local `zainod`.** Regtest has no
 hosted server, so an explicit `--server host:port` is required. `-n regtest`
 *requires* `--activation-heights`; the heights are persisted verbatim into the
 wallet's `keys.toml` (as an `[activation_heights]` table) so every later
@@ -124,7 +125,7 @@ the wallet builds are V6.
 ### The cross-component invariant
 
 The `--activation-heights` file **must** be identical to the validator's
-schedule (zebra's `configured_activation_heights`) and to what `lightwalletd`
+schedule (zebra's `configured_activation_heights`) and to what `zainod`
 serves. Transaction construction derives the consensus branch ID from these
 heights; any drift makes the validator reject transactions built while the tip
 is inside the drifted window.
@@ -149,15 +150,15 @@ is visible in the process list; use this for ephemeral test wallets only.)
 
 ## Companion node / indexer
 
-The funder is a `lightwalletd` client, and `lightwalletd` follows a Zebra node;
-both must understand Ironwood/V6 for the end-to-end flow. Use the official
-Ironwood release candidates:
+The funder speaks the lightwalletd gRPC interface to an indexer that follows
+a Zebra node; both must understand Ironwood/V6 for the end-to-end flow. In our
+stack the indexer is `zainod`. Use the official Ironwood release candidates:
 
 | Component | Ironwood RC |
 |---|---|
 | Zebra | [`v6.0.0-rc.0`](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0-rc.0) (replaces the older `zfnd/zebra:5.x`) |
-| lightwalletd | a build whose transaction parser understands V6 |
-| Zaino | [zingolabs/zaino#1362](https://github.com/zingolabs/zaino/pull/1362) (`feat/ironwood_nu6_3`) — zaino `dev` does not yet parse V6 |
+| `zainod` | [zingolabs/zaino#1362](https://github.com/zingolabs/zaino/pull/1362) (`feat/ironwood_nu6_3`) — zaino `dev` does not yet parse V6 |
+| lightwalletd (alternative) | only if not using `zainod`: a build whose transaction parser understands V6 |
 
 Confirm the exact node/indexer tags against the pinned librustzcash rev before
 a run — the crate versions above and the node's supported transaction format

--- a/doc/ironwood.md
+++ b/doc/ironwood.md
@@ -1,0 +1,173 @@
+# Ironwood (NU6.3 / V6) support
+
+`zcash-devtool` tracks the **Zcash Ironwood** upgrade so it can create, inspect,
+and exercise **V6 (Ironwood) transactions** end to end — talking to
+`lightwalletd` over gRPC as the *funder* in a local harness, and as a general
+inspection/PCZT tool.
+
+Ironwood is the **NU6.3** network upgrade. In `librustzcash` the network
+upgrade `NetworkUpgrade::Nu6_3` is a *stable* (non-`cfg`-gated) variant whose
+consensus branch ID selects `TxVersion::V6`, so V6 transactions build and parse
+on an ordinary `cargo build` — **no `--cfg zcash_unstable` flag is required**.
+(The separate `zcash_unstable = "nu7"` gate covers a *later* upgrade — ZIP-233
+and friends — which this tool does not use.)
+
+## What this tool depends on
+
+Ironwood support comes from `librustzcash` main, pulled in via
+`[patch.crates-io]` in `Cargo.toml`: every `librustzcash` crate we use
+(directly or transitively) is repointed to
+[`zcash/librustzcash`](https://github.com/zcash/librustzcash) at a single
+pinned rev. The higher-level crates (`zcash_client_backend 0.23`,
+`zcash_client_sqlite 0.21`, `pczt 0.7`, `zip321 0.8`) keep their crates.io
+version numbers but depend on `-pre` lower crates, so a git source is required
+— the crates.io releases can't be used directly. `orchard` is **not** patched:
+it resolves to `orchard 0.15.0-pre.1` from crates.io for us and for the
+patched crates alike.
+
+Pre-release crate versions currently in the tree:
+
+| Crate | Version |
+|---|---|
+| `orchard` | `0.15.0-pre.1` (crates.io) |
+| `zcash_primitives` | `0.29.0-pre.0` |
+| `zcash_proofs` | `0.29.0-pre.0` |
+| `zcash_keys` | `0.15.0-pre.0` |
+| `zcash_transparent` | `0.9.0-pre.0` |
+| `zcash_protocol` | `0.10.0-pre.0` |
+| `zcash_address` | `0.13.0-pre.0` |
+
+To move to a newer rev, bump every `rev = "…"` line in `[patch.crates-io]`
+(they must stay in lockstep) and any `-pre` version requirements in
+`[dependencies]` that the new rev advances.
+
+## When does Ironwood activate?
+
+V6/Ironwood transactions are produced once the chain tip is **at or above the
+NU6.3 activation height** for the network the wallet is configured with. The
+network's activation schedule decides this:
+
+| Network | NU6.3 (Ironwood) activation | Notes |
+|---|---|---|
+| **mainnet** | not yet scheduled (`None`) | V6 is inactive until NU6.3 is assigned a mainnet height in a future `zcash_protocol` release. Nothing to configure here; the tool follows the schedule baked into `zcash_protocol`. |
+| **testnet** | height **4,134,000** | Scheduled in `zcash_protocol`. Point the wallet at a testnet `lightwalletd` (`-n test -s zecrocks`) and it produces V6 transactions once the tip passes 4,134,000. |
+| **regtest** | **operator-chosen** | Set via the `--activation-heights` file at `init` (see below). This is how you get a chain where Ironwood is active from the start for local testing. |
+
+Because activation is driven entirely by the network parameters, **testnet works
+today and mainnet will work automatically** once NU6.3 is assigned a mainnet
+height upstream — no code change here is needed for the mainnet cutover beyond
+bumping to the `zcash_protocol` release that carries the height.
+
+> **Scope of "support" today.** The tool builds and parses V6 transactions and
+> runs against a NU6.3 chain. Post-NU6.3, Orchard outputs use the post-NU6.3
+> circuit. The wallet does **not** yet construct the separate Ironwood
+> value-pool bundle (upstream `librustzcash` main currently builds V6
+> transactions with `ironwood_anchor: None`); when that lands upstream it will
+> flow through the normal `wallet send` / `pay` path with no change here. The
+> low-level pieces are already wired: the PCZT prover creates an Ironwood proof
+> when a bundle is present (`pczt prove`), `inspect` decodes V6, and
+> `wallet send --tx-version 6` is accepted.
+
+## Using regtest
+
+Regtest support lives behind the `regtest_support` Cargo feature and is the way
+to stand up a local chain where Ironwood is active from an early height.
+
+**1. Build with the feature:**
+
+```bash
+cargo build --release --features regtest_support
+```
+
+**2. Write an activation-heights file.** A TOML file gives one entry per
+network upgrade: a height, or `"never"` for an upgrade that is deliberately
+inactive on this chain. A missing key also means "not active", but is warned
+about on every load, since absence may just mean the file predates the tool's
+knowledge of that upgrade. `nu6_3` is the Ironwood key:
+
+```toml
+# regtest-heights.toml — must match the validator (zebra) and lightwalletd.
+overwinter = 1
+sapling    = 1
+blossom    = 1
+heartwood  = 1
+canopy     = 1
+nu5        = 1
+nu6        = 1
+nu6_1      = 1
+nu6_2      = 1
+nu6_3      = 1   # Ironwood / V6 active from height 1; write "never" to disable
+```
+
+**3. Initialise the wallet against your local `lightwalletd`.** Regtest has no
+hosted server, so an explicit `--server host:port` is required. `-n regtest`
+*requires* `--activation-heights`; the heights are persisted verbatim into the
+wallet's `keys.toml` (as an `[activation_heights]` table) so every later
+command agrees with the chain:
+
+```bash
+cargo run --release --features regtest_support -- \
+  wallet -w ./regtest-wallet init \
+  --name dev -i ./regtest-wallet/dev-key.txt \
+  -n regtest --activation-heights ./regtest-heights.toml \
+  -s 127.0.0.1:9067
+```
+
+`init` reads the mnemonic interactively, but when stdin is not a terminal it
+reads one line from stdin instead — so an automated funder can pipe a known
+phrase in (`echo "$PHRASE" | cargo run … init …`) without a TTY.
+
+**4. Fund and transact as usual** (`wallet sync`, `wallet shield`,
+`wallet send`, …). Once the tip is at/above the `nu6_3` height, the transactions
+the wallet builds are V6.
+
+### The cross-component invariant
+
+The `--activation-heights` file **must** be identical to the validator's
+schedule (zebra's `configured_activation_heights`) and to what `lightwalletd`
+serves. Transaction construction derives the consensus branch ID from these
+heights; any drift makes the validator reject transactions built while the tip
+is inside the drifted window.
+
+### Offline address derivation for funders
+
+`wallet derive-address` derives an account's default unified and transparent
+addresses straight from a mnemonic, with **no wallet directory and no server**:
+
+```bash
+cargo run --release --features regtest_support -- \
+  wallet derive-address -n regtest --mnemonic "$PHRASE"
+# Unified Address: u1...
+# Transparent Address: t1...
+```
+
+This lets a harness learn the funder's transparent address *before* the chain
+exists (e.g. so zebra can mine coinbase to it as `miner_address`). The address
+is the first account's default receiver — exactly what `create_account`
+produces and what `wallet shield` later scans. (A mnemonic on the command line
+is visible in the process list; use this for ephemeral test wallets only.)
+
+## Companion node / indexer
+
+The funder is a `lightwalletd` client, and `lightwalletd` follows a Zebra node;
+both must understand Ironwood/V6 for the end-to-end flow. Use the official
+Ironwood release candidates:
+
+| Component | Ironwood RC |
+|---|---|
+| Zebra | [`v6.0.0-rc.0`](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0-rc.0) (replaces the older `zfnd/zebra:5.x`) |
+| lightwalletd | a build whose transaction parser understands V6 |
+| Zaino | [zingolabs/zaino#1362](https://github.com/zingolabs/zaino/pull/1362) (`feat/ironwood_nu6_3`) — zaino `dev` does not yet parse V6 |
+
+Confirm the exact node/indexer tags against the pinned librustzcash rev before
+a run — the crate versions above and the node's supported transaction format
+must agree.
+
+## Provenance
+
+The regtest walkthrough, funder workflow, and offline derivation sections were
+adapted from the `zecrocks/zcash-devtool` `ironwood-valar` branch, which
+pioneered end-to-end Ironwood testing against the librustzcash Ironwood release
+candidates. Wallet-level Ironwood balances and spending remain on that branch;
+they depend on `zcash_client_backend` APIs (e.g. `ironwood_balance()`) that
+have not yet merged to librustzcash main.

--- a/docs/adr/0001-explicit-inactive-heights-encoding.md
+++ b/docs/adr/0001-explicit-inactive-heights-encoding.md
@@ -1,0 +1,32 @@
+# Explicit "never" encoding for inactive network upgrades in activation-heights TOML
+
+Status: accepted
+
+Activation-heights files (and the copy persisted in the wallet config)
+originally encoded "upgrade not active" only as key absence. That made a stale
+file — one written before the tool learned of a newer upgrade, e.g. NU6.3 —
+indistinguishable from a deliberate opt-out, and Height Drift from stale files
+surfaces only as validator-rejected transactions. We decided that a key may now
+be written as `"never"` (Explicitly Inactive); bare absence (Implicitly
+Inactive) remains legal and still means inactive, but is warned about whenever
+the file or wallet config is loaded.
+
+## Considered Options
+
+- **Warn on absence, no schema change** — rejected: the warning would be
+  unsilenceable for genuine opt-outs, since absence was the only way to say
+  "inactive".
+- **Require complete files at wallet creation** (every known upgrade stated as
+  a height or `"never"`) — rejected in favor of lenient-with-warning: each new
+  upgrade the tool learns about would break existing committed heights files
+  at `init` until edited.
+- **Backfill omitted keys as `"never"` at creation** — rejected: it launders
+  "operator never considered this upgrade" into "operator chose never",
+  destroying the distinction the encoding exists to preserve.
+
+## Consequences
+
+- The activation-heights schema in operator-committed files is extended;
+  reverting `"never"` support after files use it would break those files.
+- Wallet-command load paths warn on any known-but-absent upgrade key; the
+  warning is silenced by stating the key explicitly (a height or `"never"`).

--- a/docs/adr/0002-keep-localnetwork-as-regtest-consensus-backend.md
+++ b/docs/adr/0002-keep-localnetwork-as-regtest-consensus-backend.md
@@ -1,0 +1,29 @@
+# Keep `LocalNetwork` (zcash_protocol `local-consensus`) as the regtest consensus backend
+
+Status: accepted
+
+The devtool-local `ActivationHeights` type owns the TOML schema and verbatim
+persistence, but consensus queries for regtest still convert through
+`zcash_protocol`'s `LocalNetwork` rather than implementing `Parameters`
+directly on `ActivationHeights`. This looks like a prunable indirection — the
+`local-consensus` feature could be dropped with ~50 lines of local consensus
+logic — and we considered exactly that. We keep it deliberately:
+`LocalNetwork` struct literals (the fallback-heights constant and the inspect
+encoders) are a compile-time tripwire maintained upstream. When librustzcash
+learns a new network upgrade, those literals fail to compile at the next
+dependency bump, forcing this tool to confront the upgrade explicitly — the
+NU6.3 work was enumerated by precisely these errors. A self-owned
+`Parameters` impl would compile silently through a new upgrade, leaving
+regtest wallets with a stale consensus view guarded only by a runtime
+warning, and would move activation-ordering semantics from upstream's tests
+into ours. The feature itself gates one dependency-free module, so pruning
+buys nothing measurable.
+
+## Consequences
+
+- Do not replace the `to_local_network()` conversion with a direct
+  `Parameters` impl on `ActivationHeights`; the "redundant" conversion is the
+  point.
+- The `LocalNetwork` literals in the inspect commands must stay exhaustive
+  struct literals (no `..Default::default()` shortcuts), or the tripwire is
+  disarmed.

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -199,10 +199,12 @@ fn inspect_zip321(request: TransactionRequest) {
         match payment.amount() {
             Some(amount) => {
                 let zats = amount.into_u64();
+                // A ZIP 321 payment request is network-agnostic, so default the
+                // ticker to mainnet's (ZEC) for display.
                 eprintln!(
-                    "   - Amount: {} zatoshis ({} ZEC)",
+                    "   - Amount: {} zatoshis ({})",
                     zats,
-                    format_zec(amount)
+                    format_zec(amount, NetworkType::Main)
                 );
             }
             None => eprintln!("   - Amount: not specified"),

--- a/src/commands/inspect.rs
+++ b/src/commands/inspect.rs
@@ -42,7 +42,6 @@ lazy_static! {
             Some(&folder.join("sprout-groth16.params")),
         )
     };
-    static ref ORCHARD_VK: orchard::circuit::VerifyingKey = orchard::circuit::VerifyingKey::build();
 }
 
 #[derive(Debug, Args)]

--- a/src/commands/inspect/keys.rs
+++ b/src/commands/inspect/keys.rs
@@ -201,6 +201,7 @@ pub(crate) fn inspect_sapling_extsk(data: Vec<u8>, network: NetworkType) {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        nu6_3: None,
                         #[cfg(zcash_unstable = "nu7")]
                         nu7: None,
                     }),
@@ -223,6 +224,7 @@ pub(crate) fn inspect_sapling_extsk(data: Vec<u8>, network: NetworkType) {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        nu6_3: None,
                         #[cfg(zcash_unstable = "nu7")]
                         nu7: None,
                     }),

--- a/src/commands/inspect/keys/view.rs
+++ b/src/commands/inspect/keys/view.rs
@@ -121,6 +121,7 @@ pub(crate) fn inspect_sapling_extfvk(data: Vec<u8>, network: NetworkType) {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        nu6_3: None,
                         #[cfg(zcash_unstable = "nu7")]
                         nu7: None,
                     }),
@@ -143,6 +144,7 @@ pub(crate) fn inspect_sapling_extfvk(data: Vec<u8>, network: NetworkType) {
                         nu6: None,
                         nu6_1: None,
                         nu6_2: None,
+                        nu6_3: None,
                         #[cfg(zcash_unstable = "nu7")]
                         nu7: None,
                     }),

--- a/src/commands/inspect/transaction.rs
+++ b/src/commands/inspect/transaction.rs
@@ -34,7 +34,7 @@ use zcash_protocol::{
 use zcash_script::{script, solver};
 
 use super::{
-    GROTH16_PARAMS, ORCHARD_VK,
+    GROTH16_PARAMS,
     context::{Context, ZTxOut},
 };
 
@@ -141,11 +141,7 @@ pub(crate) fn inspect(
     match tx.version() {
         // TODO: If pre-v5 and no branch ID provided in context, disable signature checks.
         TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 => (),
-        TxVersion::V5 => {
-            eprintln!(" - Consensus branch ID: {:?}", tx.consensus_branch_id());
-        }
-        #[cfg(zcash_unstable = "nu7")]
-        TxVersion::V6 => {
+        TxVersion::V5 | TxVersion::V6 => {
             eprintln!(" - Consensus branch ID: {:?}", tx.consensus_branch_id());
         }
     }
@@ -547,7 +543,11 @@ pub(crate) fn inspect(
             );
         }
 
-        if let Err(e) = bundle.verify_proof(&ORCHARD_VK) {
+        // The circuit version (and thus the verifying key) is fixed by the
+        // bundle's own version, which the parser derives from the tx era.
+        let orchard_vk =
+            orchard::circuit::VerifyingKey::build(bundle.bundle_version().circuit_version());
+        if let Err(e) = bundle.verify_proof(&orchard_vk) {
             eprintln!("⚠️  Orchard proof is invalid: {e:?}");
         }
     }

--- a/src/commands/pczt/combine.rs
+++ b/src/commands/pczt/combine.rs
@@ -34,7 +34,10 @@ impl Command {
             .combine()
             .map_err(|e| anyhow!("Failed to combine PCZTs: {:?}", e))?;
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/create.rs
+++ b/src/commands/pczt/create.rs
@@ -22,7 +22,7 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     memo::{Memo, MemoBytes},
     value::Zatoshis,
 };
@@ -72,7 +72,7 @@ impl Command {
         let change_strategy = MultiOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(self.target_note_count)

--- a/src/commands/pczt/create.rs
+++ b/src/commands/pczt/create.rs
@@ -12,7 +12,8 @@ use zcash_client_backend::{
     data_api::{
         Account as _,
         wallet::{
-            ConfirmationsPolicy, create_pczt_from_proposal, input_selection::GreedyInputSelector,
+            ConfirmationsPolicy, create_pczt_from_proposal,
+            input_selection::{GreedyInputSelector, TransparentSpendPolicy},
             propose_transfer,
         },
     },
@@ -106,6 +107,9 @@ impl Command {
             &change_strategy,
             request,
             ConfirmationsPolicy::default(),
+            // Preserve the pre-upgrade behavior: transfers never spend
+            // transparent UTXOs; they must be shielded first.
+            &TransparentSpendPolicy::ShieldedOnly,
             None,
         )
         .map_err(error::Error::from)?;
@@ -119,7 +123,10 @@ impl Command {
         )
         .map_err(error::Error::from)?;
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/create_manual.rs
+++ b/src/commands/pczt/create_manual.rs
@@ -157,6 +157,7 @@ impl Command {
                 zcash_primitives::transaction::builder::BuildConfig::Standard {
                     sapling_anchor,
                     orchard_anchor,
+                    ironwood_anchor: None,
                 },
             );
             add_inputs(&mut builder, transparent_inputs)?;
@@ -255,7 +256,10 @@ impl Command {
         )?
         .finish();
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/create_max.rs
+++ b/src/commands/pczt/create_max.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use anyhow::anyhow;
 use clap::Args;
 use rand::rngs::OsRng;
 use tokio::io::{AsyncWriteExt, stdout};
@@ -91,7 +92,10 @@ impl Command {
         )
         .map_err(error::Error::from)?;
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/create_max.rs
+++ b/src/commands/pczt/create_max.rs
@@ -17,7 +17,7 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     memo::{Memo, MemoBytes},
 };
 
@@ -74,7 +74,7 @@ impl Command {
             &mut db_data,
             &params,
             account.id(),
-            &[ShieldedProtocol::Sapling, ShieldedProtocol::Orchard],
+            &[ShieldedPool::Sapling, ShieldedPool::Orchard],
             &StandardFeeRule::Zip317,
             recipient,
             memo,

--- a/src/commands/pczt/pay_manual.rs
+++ b/src/commands/pczt/pay_manual.rs
@@ -9,7 +9,8 @@ use tokio::io::{AsyncWriteExt, stdout};
 use transparent::{builder::TransparentInputInfo, bundle::TxOut};
 use zcash_client_backend::{
     fees::{
-        ChangeError, ChangeStrategy as _, DustOutputPolicy, zip317::SingleOutputChangeStrategy,
+        ChangeError, ChangeStrategy as _, DustOutputPolicy, orchard::EmptyBundleView,
+        zip317::SingleOutputChangeStrategy,
     },
     proto::service::{ChainSpec, TxFilter},
 };
@@ -210,6 +211,15 @@ impl Command {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        // Fee rules depend on the Orchard bundle version, which is fixed by
+        // the consensus branch the transaction targets.
+        let orchard_bundle_version =
+            zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
+                consensus::BranchId::for_height(&params, target_height),
+                orchard::ValuePool::Orchard,
+            )
+            .ok_or_else(|| anyhow!("Target height's consensus branch does not support Orchard"))?;
+
         let balance = change_strategy
             .compute_balance::<_, Infallible>(
                 &params,
@@ -222,10 +232,13 @@ impl Command {
                     &sapling_output_values[..],
                 ),
                 &(
-                    orchard::builder::BundleType::DEFAULT,
+                    orchard_bundle_version,
                     &[][..] as &[Infallible],
                     &orchard_output_values[..],
                 ),
+                // No Ironwood bundle, and change stays in the Orchard pool.
+                &EmptyBundleView,
+                false,
                 None,
                 &(),
             )
@@ -239,6 +252,7 @@ impl Command {
             zcash_primitives::transaction::builder::BuildConfig::Standard {
                 sapling_anchor,
                 orchard_anchor,
+                ironwood_anchor: None,
             },
         );
         add_inputs(&mut builder, transparent_inputs)?;
@@ -277,6 +291,7 @@ impl Command {
             pczt_parts,
             sapling_meta,
             orchard_meta,
+            ironwood_meta: _,
         } = builder.build_for_pczt(rng, &zip317::FeeRule::standard())?;
         let created = Creator::build_from_parts(pczt_parts)
             .ok_or_else(|| anyhow!("Transaction version is incompatible with PCZTs"))?;
@@ -352,7 +367,10 @@ impl Command {
         }
 
         let pczt = updater.finish();
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/pay_manual.rs
+++ b/src/commands/pczt/pay_manual.rs
@@ -21,7 +21,7 @@ use zcash_primitives::transaction::{
     fees::zip317,
 };
 use zcash_protocol::{
-    PoolType, ShieldedProtocol,
+    PoolType, ShieldedPool,
     consensus::{self, Parameters as _},
 };
 use zip321::TransactionRequest;
@@ -146,7 +146,7 @@ impl Command {
         let change_strategy = SingleOutputChangeStrategy::<_, Infallible>::new(
             zip317::FeeRule::standard(),
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
         );
 

--- a/src/commands/pczt/prove.rs
+++ b/src/commands/pczt/prove.rs
@@ -172,14 +172,36 @@ impl Command {
 
         let prover = LocalTxProver::bundled();
 
+        // The Orchard proving key must be for the circuit version that the
+        // PCZT's consensus branch requires (pre- vs post-NU6.3 circuits
+        // differ), so derive it from the PCZT's own branch ID.
+        let orchard_pk = {
+            let branch_id =
+                zcash_protocol::consensus::BranchId::try_from(*pczt.global().consensus_branch_id())
+                    .map_err(|_| anyhow!("PCZT has an unknown consensus branch ID"))?;
+            orchard::circuit::ProvingKey::build(
+                zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
+                    branch_id,
+                    orchard::ValuePool::Orchard,
+                )
+                .ok_or_else(|| {
+                    anyhow!("PCZT's consensus branch {branch_id:?} does not support Orchard")
+                })?
+                .circuit_version(),
+            )
+        };
+
         let pczt = Prover::new(pczt)
-            .create_orchard_proof(&orchard::circuit::ProvingKey::build())
+            .create_orchard_proof(&orchard_pk)
             .map_err(|e| anyhow!("Failed to create Orchard proof: {:?}", e))?
             .create_sapling_proofs(&prover, &prover)
             .map_err(|e| anyhow!("Failed to create Sapling proofs: {:?}", e))?
             .finish();
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/prove.rs
+++ b/src/commands/pczt/prove.rs
@@ -172,14 +172,21 @@ impl Command {
 
         let prover = LocalTxProver::bundled();
 
-        // The Orchard proving key must be for the circuit version that the
-        // PCZT's consensus branch requires (pre- vs post-NU6.3 circuits
-        // differ), so derive it from the PCZT's own branch ID.
-        let orchard_pk = {
-            let branch_id =
-                zcash_protocol::consensus::BranchId::try_from(*pczt.global().consensus_branch_id())
-                    .map_err(|_| anyhow!("PCZT has an unknown consensus branch ID"))?;
-            orchard::circuit::ProvingKey::build(
+        let raw_branch_id = *pczt.global().consensus_branch_id();
+        let mut prover_role = Prover::new(pczt);
+
+        // The proving key is expensive to build, so only do so when a bundle
+        // actually needs a proof, and build it for the circuit version that
+        // the PCZT's consensus branch requires (pre- vs post-NU6.3 circuits
+        // differ) by deriving it from the PCZT's own branch ID. Orchard and
+        // Ironwood share one circuit on every branch where Ironwood exists
+        // (post-NU6.3), so a single key serves both bundles.
+        let needs_orchard = prover_role.requires_orchard_proof();
+        let needs_ironwood = prover_role.requires_ironwood_proof();
+        if needs_orchard || needs_ironwood {
+            let branch_id = zcash_protocol::consensus::BranchId::try_from(raw_branch_id)
+                .map_err(|_| anyhow!("PCZT has an unknown consensus branch ID"))?;
+            let pk = orchard::circuit::ProvingKey::build(
                 zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
                     branch_id,
                     orchard::ValuePool::Orchard,
@@ -188,12 +195,20 @@ impl Command {
                     anyhow!("PCZT's consensus branch {branch_id:?} does not support Orchard")
                 })?
                 .circuit_version(),
-            )
-        };
+            );
+            if needs_orchard {
+                prover_role = prover_role
+                    .create_orchard_proof(&pk)
+                    .map_err(|e| anyhow!("Failed to create Orchard proof: {:?}", e))?;
+            }
+            if needs_ironwood {
+                prover_role = prover_role
+                    .create_ironwood_proof(&pk)
+                    .map_err(|e| anyhow!("Failed to create Ironwood proof: {:?}", e))?;
+            }
+        }
 
-        let pczt = Prover::new(pczt)
-            .create_orchard_proof(&orchard_pk)
-            .map_err(|e| anyhow!("Failed to create Orchard proof: {:?}", e))?
+        let pczt = prover_role
             .create_sapling_proofs(&prover, &prover)
             .map_err(|e| anyhow!("Failed to create Sapling proofs: {:?}", e))?
             .finish();

--- a/src/commands/pczt/qr.rs
+++ b/src/commands/pczt/qr.rs
@@ -49,14 +49,12 @@ impl Send {
 
         let pczt = Pczt::parse(&buf).map_err(|e| anyhow!("Failed to read PCZT: {:?}", e))?;
 
+        let pczt_data = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
         let mut pczt_packet = vec![];
-        minicbor::encode(
-            &ZcashPczt {
-                data: pczt.serialize(),
-            },
-            &mut pczt_packet,
-        )
-        .map_err(|e| anyhow!("Failed to encode PCZT packet: {:?}", e))?;
+        minicbor::encode(&ZcashPczt { data: pczt_data }, &mut pczt_packet)
+            .map_err(|e| anyhow!("Failed to encode PCZT packet: {:?}", e))?;
 
         #[cfg(feature = "tui")]
         let tui_handle = if self.tui {
@@ -218,7 +216,10 @@ impl Receive {
         )
         .map_err(|e| anyhow!("Failed to read PCZT from QR codes: {:?}", e))?;
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/redact.rs
+++ b/src/commands/pczt/redact.rs
@@ -34,7 +34,10 @@ impl Command {
             })?
             .finish();
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/send.rs
+++ b/src/commands/pczt/send.rs
@@ -41,7 +41,10 @@ impl Command {
             &mut db_data,
             pczt,
             Some((&spend_vk, &output_vk)),
-            Some(&orchard::circuit::VerifyingKey::build()),
+            // Passing `None` makes the extractor build an Orchard verifying
+            // key for the circuit version the PCZT's consensus branch
+            // requires (pre- vs post-NU6.3 circuits differ).
+            None,
         )
         .map_err(|e| anyhow!("Failed to extract and store transaction from PCZT: {:?}", e))?;
 

--- a/src/commands/pczt/shield.rs
+++ b/src/commands/pczt/shield.rs
@@ -9,7 +9,7 @@ use transparent::address::TransparentAddress;
 use uuid::Uuid;
 use zcash_client_backend::{
     data_api::{
-        Account as _, TransparentOutputFilter, WalletRead,
+        Account as _, CoinbaseFilter, WalletRead,
         wallet::{
             ConfirmationsPolicy, create_pczt_from_proposal, input_selection::GreedyInputSelector,
             propose_shielding,
@@ -97,7 +97,7 @@ impl Command {
             &from_addrs,
             account.id(),
             confirmations_policy,
-            TransparentOutputFilter::All,
+            CoinbaseFilter::AllTransparentOutputs,
         )
         .map_err(error::Error::Shield)?;
 
@@ -110,7 +110,10 @@ impl Command {
         )
         .map_err(error::Error::Shield)?;
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/shield.rs
+++ b/src/commands/pczt/shield.rs
@@ -20,7 +20,7 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
 use zcash_keys::encoding::AddressCodec;
-use zcash_protocol::{ShieldedProtocol, value::Zatoshis};
+use zcash_protocol::{ShieldedPool, value::Zatoshis};
 
 use crate::{commands::select_account, config::WalletConfig, data::get_db_paths, error};
 
@@ -64,7 +64,7 @@ impl Command {
         let change_strategy = MultiOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(self.target_note_count)

--- a/src/commands/pczt/sign.rs
+++ b/src/commands/pczt/sign.rs
@@ -202,7 +202,10 @@ impl Command {
 
         let pczt = signer.finish();
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/update_with_derivation.rs
+++ b/src/commands/pczt/update_with_derivation.rs
@@ -8,7 +8,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, stdin, stdout};
 use transparent::{address::TransparentAddress, pczt::Bip32Derivation, zip48};
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_protocol::{
-    PoolType,
+    PoolType, ShieldedPool,
     consensus::{self, NetworkConstants, Parameters},
 };
 use zcash_script::solver;
@@ -149,12 +149,18 @@ impl Command {
 
                 add_orchard(updater, fvk, derivation)
             }
+            PoolType::Shielded(ShieldedPool::Ironwood) => {
+                return Err(anyhow!("Ironwood is not yet supported"));
+            }
         }
         .map_err(|e| anyhow!("{e:?}"))?;
 
         let pczt = updater.finish();
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/pczt/update_with_signature.rs
+++ b/src/commands/pczt/update_with_signature.rs
@@ -10,7 +10,7 @@ use zcash_primitives::transaction::{
     TransactionData, TxDigests, sighash::SignableInput, sighash_v5::v5_signature_hash,
     txid::TxIdDigester,
 };
-use zcash_protocol::PoolType;
+use zcash_protocol::{PoolType, ShieldedPool};
 
 // Options accepted for the `pczt update-with-signature` command
 #[derive(Debug, Args)]
@@ -46,12 +46,18 @@ impl Command {
             }
             PoolType::SAPLING => Err(anyhow!("TODO: Maybe support this")),
             PoolType::ORCHARD => Err(anyhow!("TODO: Maybe support this")),
+            PoolType::Shielded(ShieldedPool::Ironwood) => {
+                Err(anyhow!("Ironwood is not yet supported"))
+            }
         }
         .map_err(|e| anyhow!("{e:?}"))?;
 
         let pczt = signer.finish();
 
-        stdout().write_all(&pczt.serialize()).await?;
+        let pczt_bytes = pczt
+            .serialize()
+            .map_err(|e| anyhow!("Failed to serialize PCZT: {:?}", e))?;
+        stdout().write_all(&pczt_bytes).await?;
 
         Ok(())
     }

--- a/src/commands/wallet.rs
+++ b/src/commands/wallet.rs
@@ -2,6 +2,7 @@ use clap::Subcommand;
 
 pub(crate) mod balance;
 pub(crate) mod delete_account;
+pub(crate) mod derive_address;
 pub(crate) mod derive_path;
 pub(crate) mod display_mnemonic;
 pub(crate) mod enhance;
@@ -74,6 +75,11 @@ pub(crate) enum Command {
 
     /// List the addresses for an account in the wallet
     ListAddresses(list_addresses::Command),
+
+    /// Derive a mnemonic's default unified and transparent addresses, offline
+    /// (no wallet or server required). Prints `Unified Address: <ua>` and
+    /// `Transparent Address: <t-addr>`.
+    DeriveAddress(derive_address::Command),
 
     /// Derive key material at a particular path below the wallet seed
     DerivePath(derive_path::Command),

--- a/src/commands/wallet/balance.rs
+++ b/src/commands/wallet/balance.rs
@@ -10,6 +10,7 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::WalletDb;
 use zcash_keys::keys::UnifiedAddressRequest;
+use zcash_protocol::consensus::{NetworkType, Parameters};
 use zcash_protocol::value::{COIN, Zatoshis};
 
 use crate::{
@@ -120,19 +121,20 @@ impl Command {
                     (*progress.numerator() as f64) * 100f64 / (*progress.denominator() as f64)
                 );
             }
-            println!("    Balance: {}", printer.format(balance.total()));
+            let net = params.network_type();
+            println!("    Balance: {}", printer.format(balance.total(), net));
             println!(
                 "     Sapling Spendable: {}",
-                printer.format(balance.sapling_balance().spendable_value()),
+                printer.format(balance.sapling_balance().spendable_value(), net),
             );
             println!(
                 "     Orchard Spendable: {}",
-                printer.format(balance.orchard_balance().spendable_value()),
+                printer.format(balance.orchard_balance().spendable_value(), net),
             );
             #[cfg(feature = "transparent-inputs")]
             println!(
                 "  Unshielded Spendable: {}",
-                printer.format(balance.unshielded_balance().spendable_value()),
+                printer.format(balance.unshielded_balance().spendable_value(), net),
             );
         } else {
             println!("Insufficient information to build a wallet summary.");
@@ -163,18 +165,18 @@ impl ValuePrinter {
         }
     }
 
-    fn format(&self, value: Zatoshis) -> String {
+    fn format(&self, value: Zatoshis, network: NetworkType) -> String {
         match self {
             ValuePrinter::WithConversion { currency, rate } => {
                 format!(
                     "{} ({}{:.2})",
-                    format_zec(value),
+                    format_zec(value, network),
                     currency.symbol(),
                     rate * Decimal::from_u64(value.into_u64()).unwrap()
                         / Decimal::from_u64(COIN).unwrap(),
                 )
             }
-            ValuePrinter::ZecOnly => format_zec(value),
+            ValuePrinter::ZecOnly => format_zec(value, network),
         }
     }
 }

--- a/src/commands/wallet/derive_address.rs
+++ b/src/commands/wallet/derive_address.rs
@@ -1,0 +1,61 @@
+//! Offline derivation of a wallet's default addresses from a mnemonic.
+//!
+//! Unlike the other wallet commands this needs no chain and no on-disk wallet — it derives the
+//! account's default unified address and its transparent receiver straight from the mnemonic. It
+//! exists so automated regtest funding can learn the funding wallet's transparent address *before*
+//! a chain exists (zebra needs it as its coinbase `miner_address` at launch), keeping the funder on
+//! a single chain so its wallet birthday anchor stays valid.
+
+use anyhow::anyhow;
+use bip0039::{English, Mnemonic};
+use clap::Args;
+use secrecy::Zeroize;
+use zcash_keys::{
+    encoding::AddressCodec,
+    keys::{UnifiedAddressRequest, UnifiedSpendingKey},
+};
+
+use crate::data::Network;
+
+// Options accepted for the `derive-address` command
+#[derive(Debug, Args)]
+pub(crate) struct Command {
+    /// The mnemonic phrase to derive from.
+    #[arg(long)]
+    mnemonic: String,
+
+    /// The network: "main", "test" or "regtest".
+    #[arg(short, long)]
+    #[arg(value_parser = Network::parse)]
+    network: Network,
+}
+
+impl Command {
+    pub(crate) fn run(self) -> anyhow::Result<()> {
+        // `data::Network` implements `Parameters` directly; address derivation
+        // only needs the network *type*, so the regtest activation heights are
+        // irrelevant here.
+        let params = self.network;
+
+        let mnemonic = <Mnemonic<English>>::from_phrase(self.mnemonic.trim())
+            .map_err(|e| anyhow!("invalid mnemonic: {e}"))?;
+        let mut seed = mnemonic.to_seed("");
+        let usk = UnifiedSpendingKey::from_seed(&params, &seed, zip32::AccountId::ZERO)
+            .map_err(|e| anyhow!("failed to derive spending key: {e}"))?;
+        seed.zeroize();
+
+        // The default address of the first account — exactly what `create_account` produces and
+        // what the wallet scans, so a coinbase mined to this transparent receiver is detected.
+        let (ua, _) = usk
+            .to_unified_full_viewing_key()
+            .default_address(UnifiedAddressRequest::AllAvailableKeys)
+            .map_err(|e| anyhow!("failed to derive default address: {e}"))?;
+
+        println!("Unified Address: {}", ua.encode(&params));
+        if let Some(taddr) = ua.transparent() {
+            println!("Transparent Address: {}", taddr.encode(&params));
+        }
+
+        Ok(())
+    }
+}

--- a/src/commands/wallet/derive_path.rs
+++ b/src/commands/wallet/derive_path.rs
@@ -9,7 +9,7 @@ use zcash_keys::{
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey},
 };
 use zcash_protocol::{
-    PoolType,
+    PoolType, ShieldedPool,
     consensus::{NetworkConstants, Parameters},
 };
 
@@ -288,6 +288,9 @@ impl Command {
                     println!(" - UFVK: {}", ufvk.encode(&params));
                     println!(" - Default address: {}", ua.encode(&params));
                 }
+            }
+            PoolType::Shielded(ShieldedPool::Ironwood) => {
+                return Err(anyhow!("Ironwood derivation is not yet supported"));
             }
         }
 

--- a/src/commands/wallet/init.rs
+++ b/src/commands/wallet/init.rs
@@ -41,9 +41,10 @@ pub(crate) struct Command {
 
     /// Required for `-n regtest`: a TOML file giving the validator's
     /// activation height per network upgrade (keys: overwinter, sapling,
-    /// blossom, heartwood, canopy, nu5, nu6, nu6_1, nu6_2; a missing key
-    /// means the upgrade is inactive). The heights are persisted in the
-    /// wallet config so later commands agree. Rejected for main/test.
+    /// blossom, heartwood, canopy, nu5, nu6, nu6_1, nu6_2, nu6_3; each a
+    /// height or "never"; a missing key means the upgrade is inactive but
+    /// warns on load). The heights are persisted verbatim in the wallet
+    /// config so later commands agree. Rejected for main/test.
     #[cfg(feature = "regtest_support")]
     #[arg(long)]
     activation_heights: Option<std::path::PathBuf>,

--- a/src/commands/wallet/list_tx.rs
+++ b/src/commands/wallet/list_tx.rs
@@ -6,12 +6,16 @@ use uuid::Uuid;
 
 use zcash_protocol::{
     PoolType, TxId,
-    consensus::BlockHeight,
+    consensus::{BlockHeight, NetworkType, Parameters},
     memo::{Memo, MemoBytes},
     value::{ZatBalance, Zatoshis},
 };
 
-use crate::{data::get_db_paths, ui::format_zec};
+use crate::{
+    config::get_wallet_network,
+    data::get_db_paths,
+    ui::{format_zec, ticker},
+};
 
 // Options accepted for the `list-tx` command
 #[derive(Debug, Args)]
@@ -50,6 +54,7 @@ impl ListMode {
 
 impl Command {
     pub(crate) fn run(self, wallet_dir: Option<String>) -> anyhow::Result<()> {
+        let net = get_wallet_network(wallet_dir.as_ref())?.network_type();
         let (_, db_data) = get_db_paths(wallet_dir);
         let mode = self
             .mode
@@ -166,7 +171,7 @@ impl Command {
                     "mined_height": tx.mined_height.map(u32::from),
                 }));
             } else {
-                tx.print(mode)?;
+                tx.print(mode, net)?;
             }
         }
 
@@ -227,11 +232,11 @@ impl WalletTxOutput {
         })
     }
 
-    fn print_text(&self) {
+    fn print_text(&self, net: NetworkType) {
         println!("  Output {} ({})", self.output_index, self.pool);
         println!(
             "    Value: {}{}",
-            format_zec(self.value),
+            format_zec(self.value, net),
             if self.is_change {
                 " (Change)"
             } else if self.from_account.is_some() && self.to_account.is_some() {
@@ -265,7 +270,7 @@ impl WalletTxOutput {
         }
     }
 
-    fn print_csv(&self, context: &WalletTx) -> Result<(), anyhow::Error> {
+    fn print_csv(&self, context: &WalletTx, net: NetworkType) -> Result<(), anyhow::Error> {
         if self.is_change {
             //neither send nor receive, skip
             return Ok(());
@@ -290,8 +295,8 @@ impl WalletTxOutput {
                 .map(time::OffsetDateTime::from_unix_timestamp)
                 .transpose()?
                 .map_or(Ok("".to_string()), |t| t.format(format))?;
-            let symbol = "ZEC";
-            let volume = format_zec(self.value);
+            let symbol = ticker(net);
+            let volume = format_zec(self.value, net);
             let currency = "USD";
             let (account_id, account_name) = self
                 .to_account
@@ -303,8 +308,11 @@ impl WalletTxOutput {
                 .map_or("".to_string(), |n| format!(" ({n})"));
             let total = "";
             let price = "";
-            let fee = context.fee_paid.map(format_zec).unwrap_or("".to_string());
-            let fee_currency = "ZEC";
+            let fee = context
+                .fee_paid
+                .map(|f| format_zec(f, net))
+                .unwrap_or("".to_string());
+            let fee_currency = ticker(net);
             let memo = self.memo.as_ref().map_or("".to_string(), |m| match m {
                 Memo::Empty => "".to_string(),
                 Memo::Text(text_memo) => text_memo.to_string(),
@@ -367,17 +375,17 @@ impl WalletTx {
         })
     }
 
-    fn print(&self, mode: ListMode) -> Result<(), anyhow::Error> {
+    fn print(&self, mode: ListMode, net: NetworkType) -> Result<(), anyhow::Error> {
         match mode {
             ListMode::Text => {
-                self.print_text();
+                self.print_text(net);
                 Ok(())
             }
-            ListMode::Csv => self.print_csv(),
+            ListMode::Csv => self.print_csv(net),
         }
     }
 
-    fn print_text(&self) {
+    fn print_text(&self, net: NetworkType) {
         let height_to_str = |height: Option<BlockHeight>, def: &str| {
             height.map(|h| h.to_string()).unwrap_or(def.to_owned())
         };
@@ -399,11 +407,14 @@ impl WalletTx {
                 height_to_str(self.expiry_height, "Unknown"),
             );
         }
-        println!("    Amount: {}", format_zec(self.account_balance_delta));
+        println!(
+            "    Amount: {}",
+            format_zec(self.account_balance_delta, net)
+        );
         println!(
             "  Fee paid: {}",
             self.fee_paid
-                .map(format_zec)
+                .map(|f| format_zec(f, net))
                 .as_deref()
                 .unwrap_or("Unknown"),
         );
@@ -412,13 +423,13 @@ impl WalletTx {
             self.sent_note_count, self.received_note_count, self.memo_count,
         );
         for output in &self.outputs {
-            output.print_text()
+            output.print_text(net)
         }
     }
 
-    fn print_csv(&self) -> Result<(), anyhow::Error> {
+    fn print_csv(&self, net: NetworkType) -> Result<(), anyhow::Error> {
         for output in &self.outputs {
-            output.print_csv(self)?;
+            output.print_csv(self, net)?;
         }
 
         Ok(())

--- a/src/commands/wallet/list_tx.rs
+++ b/src/commands/wallet/list_tx.rs
@@ -200,6 +200,7 @@ impl WalletTxOutput {
             0 => Some(PoolType::Transparent),
             2 => Some(PoolType::SAPLING),
             3 => Some(PoolType::ORCHARD),
+            4 => Some(PoolType::IRONWOOD),
             _ => None,
         }
     }

--- a/src/commands/wallet/list_unspent.rs
+++ b/src/commands/wallet/list_unspent.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 use zcash_client_backend::data_api::{Account as _, InputSource, WalletRead};
 use zcash_client_sqlite::WalletDb;
 use zcash_protocol::ShieldedPool;
+use zcash_protocol::consensus::Parameters;
 
 use crate::{
     commands::select_account, config::get_wallet_network, data::get_db_paths, error, ui::format_zec,
@@ -37,11 +38,12 @@ impl Command {
             &[],
         )?;
 
+        let net = params.network_type();
         for note in notes.sapling() {
             println!(
                 "Sapling {}: {}",
                 note.internal_note_id(),
-                format_zec(note.note_value()?)
+                format_zec(note.note_value()?, net)
             );
         }
 
@@ -49,7 +51,7 @@ impl Command {
             println!(
                 "Orchard {}: {}",
                 note.internal_note_id(),
-                format_zec(note.note_value()?)
+                format_zec(note.note_value()?, net)
             );
         }
 

--- a/src/commands/wallet/list_unspent.rs
+++ b/src/commands/wallet/list_unspent.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use uuid::Uuid;
 use zcash_client_backend::data_api::{Account as _, InputSource, WalletRead};
 use zcash_client_sqlite::WalletDb;
-use zcash_protocol::ShieldedProtocol;
+use zcash_protocol::ShieldedPool;
 
 use crate::{
     commands::select_account, config::get_wallet_network, data::get_db_paths, error, ui::format_zec,
@@ -32,7 +32,7 @@ impl Command {
 
         let notes = db_data.select_unspent_notes(
             account.id(),
-            &[ShieldedProtocol::Sapling, ShieldedProtocol::Orchard],
+            &[ShieldedPool::Sapling, ShieldedPool::Orchard],
             target_height,
             &[],
         )?;

--- a/src/commands/wallet/propose.rs
+++ b/src/commands/wallet/propose.rs
@@ -17,7 +17,7 @@ use zcash_client_backend::{
     fees::{DustOutputPolicy, SplitPolicy, StandardFeeRule, zip317::MultiOutputChangeStrategy},
 };
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
-use zcash_protocol::{ShieldedProtocol, value::Zatoshis};
+use zcash_protocol::{ShieldedPool, value::Zatoshis};
 use zip321::{Payment, TransactionRequest};
 
 use crate::{
@@ -61,7 +61,7 @@ impl Command {
         let change_strategy = MultiOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(self.target_note_count)

--- a/src/commands/wallet/propose.rs
+++ b/src/commands/wallet/propose.rs
@@ -8,7 +8,11 @@ use zcash_address::ZcashAddress;
 use zcash_client_backend::{
     data_api::{
         Account as _,
-        wallet::{ConfirmationsPolicy, input_selection::GreedyInputSelector, propose_transfer},
+        wallet::{
+            ConfirmationsPolicy,
+            input_selection::{GreedyInputSelector, TransparentSpendPolicy},
+            propose_transfer,
+        },
     },
     fees::{DustOutputPolicy, SplitPolicy, StandardFeeRule, zip317::MultiOutputChangeStrategy},
 };
@@ -81,6 +85,9 @@ impl Command {
             &change_strategy,
             request,
             ConfirmationsPolicy::default(),
+            // Preserve the pre-upgrade behavior: transfers never spend
+            // transparent UTXOs; they must be shielded first.
+            &TransparentSpendPolicy::ShieldedOnly,
             None,
         )
         .map_err(error::Error::from)?;

--- a/src/commands/wallet/restore_mnemonic.rs
+++ b/src/commands/wallet/restore_mnemonic.rs
@@ -33,9 +33,10 @@ pub(crate) struct Command {
 
     /// Required for `-n regtest`: a TOML file giving the validator's
     /// activation height per network upgrade (keys: overwinter, sapling,
-    /// blossom, heartwood, canopy, nu5, nu6, nu6_1, nu6_2; a missing key
-    /// means the upgrade is inactive). The heights are persisted in the
-    /// wallet config so later commands agree. Rejected for main/test.
+    /// blossom, heartwood, canopy, nu5, nu6, nu6_1, nu6_2, nu6_3; each a
+    /// height or "never"; a missing key means the upgrade is inactive but
+    /// warns on load). The heights are persisted verbatim in the wallet
+    /// config so later commands agree. Rejected for main/test.
     #[cfg(feature = "regtest_support")]
     #[arg(long)]
     activation_heights: Option<std::path::PathBuf>,

--- a/src/commands/wallet/send.rs
+++ b/src/commands/wallet/send.rs
@@ -14,7 +14,8 @@ use zcash_client_backend::{
         Account, WalletRead,
         wallet::{
             ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
-            input_selection::GreedyInputSelector, propose_transfer,
+            input_selection::{GreedyInputSelector, TransparentSpendPolicy},
+            propose_transfer,
         },
     },
     fees::{DustOutputPolicy, SplitPolicy, StandardFeeRule, standard::MultiOutputChangeStrategy},
@@ -231,6 +232,9 @@ pub(crate) async fn pay<C: PaymentContext>(
         &change_strategy,
         request,
         context.confirmations_policy(),
+        // Preserve the pre-upgrade behavior: transfers never spend
+        // transparent UTXOs; they must be shielded first.
+        &TransparentSpendPolicy::ShieldedOnly,
         context.tx_version(),
     )
     .map_err(error::Error::from)?;

--- a/src/commands/wallet/send.rs
+++ b/src/commands/wallet/send.rs
@@ -27,7 +27,7 @@ use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_primitives::transaction::TxVersion;
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
-    ShieldedProtocol,
+    ShieldedPool,
     memo::{Memo, MemoBytes},
     value::Zatoshis,
 };
@@ -214,7 +214,7 @@ pub(crate) async fn pay<C: PaymentContext>(
     let change_strategy = MultiOutputChangeStrategy::new(
         StandardFeeRule::Zip317,
         None,
-        ShieldedProtocol::Orchard,
+        ShieldedPool::Orchard,
         DustOutputPolicy::default(),
         SplitPolicy::with_min_output_value(
             NonZeroUsize::new(context.target_note_count())

--- a/src/commands/wallet/send.rs
+++ b/src/commands/wallet/send.rs
@@ -148,8 +148,9 @@ pub(crate) fn parse_tx_version(s: &str) -> anyhow::Result<TxVersion> {
     match v {
         4 => Ok(TxVersion::V4),
         5 => Ok(TxVersion::V5),
+        6 => Ok(TxVersion::V6),
         other => Err(anyhow!(
-            "Unsupported transaction version {}; expected 4 or 5",
+            "Unsupported transaction version {}; expected 4, 5 or 6",
             other
         )),
     }

--- a/src/commands/wallet/shield.rs
+++ b/src/commands/wallet/shield.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use zcash_client_backend::{
     data_api::{
-        Account, TransparentOutputFilter, WalletRead,
+        Account, CoinbaseFilter, WalletRead,
         wallet::{
             ConfirmationsPolicy, SpendingKeys, create_proposed_transactions,
             input_selection::GreedyInputSelector, propose_shielding,
@@ -130,7 +130,7 @@ impl Command {
             &from_addrs,
             account.id(),
             confirmations_policy,
-            TransparentOutputFilter::All,
+            CoinbaseFilter::AllTransparentOutputs,
         )
         .map_err(error::Error::Shield)?;
 

--- a/src/commands/wallet/shield.rs
+++ b/src/commands/wallet/shield.rs
@@ -23,7 +23,7 @@ use zcash_client_backend::{
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
 use zcash_keys::{encoding::AddressCodec, keys::UnifiedSpendingKey};
 use zcash_proofs::prover::LocalTxProver;
-use zcash_protocol::{ShieldedProtocol, value::Zatoshis};
+use zcash_protocol::{ShieldedPool, value::Zatoshis};
 
 use crate::{
     commands::select_account, config::WalletConfig, data::get_db_paths, error,
@@ -97,7 +97,7 @@ impl Command {
         let change_strategy = MultiOutputChangeStrategy::new(
             StandardFeeRule::Zip317,
             None,
-            ShieldedProtocol::Orchard,
+            ShieldedPool::Orchard,
             DustOutputPolicy::default(),
             SplitPolicy::with_min_output_value(
                 NonZeroUsize::new(self.target_note_count)

--- a/src/commands/wallet/tree/explore.rs
+++ b/src/commands/wallet/tree/explore.rs
@@ -150,6 +150,7 @@ impl App {
                     if let Some(key) = match pool {
                         ShieldedProtocol::Sapling => block.sapling_tree_size(),
                         ShieldedProtocol::Orchard => block.orchard_tree_size(),
+                        ShieldedProtocol::Ironwood => None,
                     } {
                         block_boundaries.entry(key).or_insert(block.block_height());
                     }
@@ -284,6 +285,8 @@ impl App {
                 Ok(None) => false,
                 Err(e) => todo!("{}", e),
             },
+            // The explorer's pool argument only parses "sapling"/"orchard".
+            ShieldedProtocol::Ironwood => false,
         }
     }
 
@@ -313,6 +316,10 @@ impl App {
                     )
                 })
                 .unwrap(),
+            // The explorer's pool argument only parses "sapling"/"orchard".
+            ShieldedProtocol::Ironwood => {
+                unreachable!("the tree explorer only supports Sapling and Orchard")
+            }
         };
 
         let mut address = self.address;
@@ -658,6 +665,7 @@ impl Region {
             .block(Block::bordered().title(match self.pool {
                 ShieldedProtocol::Sapling => "Sapling tree",
                 ShieldedProtocol::Orchard => "Orchard tree",
+                ShieldedProtocol::Ironwood => "Ironwood tree",
             }))
             .x_bounds([-90.0, 90.0])
             .y_bounds([-30.0, 50.0])

--- a/src/commands/wallet/tree/explore.rs
+++ b/src/commands/wallet/tree/explore.rs
@@ -22,7 +22,7 @@ use tracing::{info, warn};
 use zcash_client_backend::data_api::{WalletCommitmentTrees, WalletRead};
 use zcash_client_sqlite::{WalletDb, wallet::commitment_tree::SqliteShardStore};
 use zcash_primitives::merkle_tree::HashSer;
-use zcash_protocol::{ShieldedProtocol, consensus::BlockHeight};
+use zcash_protocol::{ShieldedPool, consensus::BlockHeight};
 
 use crate::{
     ShutdownListener,
@@ -31,10 +31,10 @@ use crate::{
     tui::{self, Tui},
 };
 
-fn parse_pool(data: &str) -> Result<ShieldedProtocol, String> {
+fn parse_pool(data: &str) -> Result<ShieldedPool, String> {
     match data {
-        "s" | "sapling" => Ok(ShieldedProtocol::Sapling),
-        "o" | "orchard" => Ok(ShieldedProtocol::Orchard),
+        "s" | "sapling" => Ok(ShieldedPool::Sapling),
+        "o" | "orchard" => Ok(ShieldedPool::Orchard),
         _ => Err(format!("Unknown pool '{data}'")),
     }
 }
@@ -62,7 +62,7 @@ fn parse_address(data: &str) -> Result<Address, String> {
 #[derive(Debug, Args)]
 pub(crate) struct Command {
     #[arg(short, long, value_parser = parse_pool)]
-    pool: ShieldedProtocol,
+    pool: ShieldedPool,
 
     /// A node address `level:index` or leaf position.
     #[arg(short, long, value_parser = parse_address)]
@@ -103,7 +103,7 @@ pub(super) struct App {
     should_quit: bool,
     notify_shutdown: Option<oneshot::Sender<()>>,
     db_data: WalletDb<rusqlite::Connection, Network, (), ()>,
-    pool: ShieldedProtocol,
+    pool: ShieldedPool,
     address: Address,
     action_tx: mpsc::UnboundedSender<Action>,
     action_rx: mpsc::UnboundedReceiver<Action>,
@@ -115,7 +115,7 @@ impl App {
     pub(super) fn new(
         notify_shutdown: oneshot::Sender<()>,
         db_data: WalletDb<rusqlite::Connection, Network, (), ()>,
-        pool: ShieldedProtocol,
+        pool: ShieldedPool,
         address: Option<Address>,
         show_block_boundaries: bool,
     ) -> anyhow::Result<Self> {
@@ -148,9 +148,9 @@ impl App {
 
                 if let Some(block) = db_data.block_metadata(height.into())? {
                     if let Some(key) = match pool {
-                        ShieldedProtocol::Sapling => block.sapling_tree_size(),
-                        ShieldedProtocol::Orchard => block.orchard_tree_size(),
-                        ShieldedProtocol::Ironwood => None,
+                        ShieldedPool::Sapling => block.sapling_tree_size(),
+                        ShieldedPool::Orchard => block.orchard_tree_size(),
+                        ShieldedPool::Ironwood => None,
                     } {
                         block_boundaries.entry(key).or_insert(block.block_height());
                     }
@@ -255,7 +255,7 @@ impl App {
 
     fn set_address_if_valid(&mut self, address: Address) -> bool {
         match self.pool {
-            ShieldedProtocol::Sapling => match self.db_data.with_sapling_tree_mut(|tree| {
+            ShieldedPool::Sapling => match self.db_data.with_sapling_tree_mut(|tree| {
                 NodeFetcher {
                     store: tree.store(),
                 }
@@ -270,7 +270,7 @@ impl App {
                 Ok(None) => false,
                 Err(e) => todo!("{}", e),
             },
-            ShieldedProtocol::Orchard => match self.db_data.with_orchard_tree_mut(|tree| {
+            ShieldedPool::Orchard => match self.db_data.with_orchard_tree_mut(|tree| {
                 NodeFetcher {
                     store: tree.store(),
                 }
@@ -286,17 +286,17 @@ impl App {
                 Err(e) => todo!("{}", e),
             },
             // The explorer's pool argument only parses "sapling"/"orchard".
-            ShieldedProtocol::Ironwood => false,
+            ShieldedPool::Ironwood => false,
         }
     }
 
     fn reload_region(&mut self) {
         let mut get_region = |address| match self.pool {
-            ShieldedProtocol::Sapling => self
+            ShieldedPool::Sapling => self
                 .db_data
                 .with_sapling_tree_mut(move |tree| {
                     Region::get(
-                        ShieldedProtocol::Sapling,
+                        ShieldedPool::Sapling,
                         NodeFetcher {
                             store: tree.store(),
                         },
@@ -304,11 +304,11 @@ impl App {
                     )
                 })
                 .unwrap(),
-            ShieldedProtocol::Orchard => self
+            ShieldedPool::Orchard => self
                 .db_data
                 .with_orchard_tree_mut(move |tree| {
                     Region::get(
-                        ShieldedProtocol::Orchard,
+                        ShieldedPool::Orchard,
                         NodeFetcher {
                             store: tree.store(),
                         },
@@ -317,7 +317,7 @@ impl App {
                 })
                 .unwrap(),
             // The explorer's pool argument only parses "sapling"/"orchard".
-            ShieldedProtocol::Ironwood => {
+            ShieldedPool::Ironwood => {
                 unreachable!("the tree explorer only supports Sapling and Orchard")
             }
         };
@@ -569,7 +569,7 @@ const Y_CHILD: f64 = -ROW_SPACING;
 /// `Direction` lets us move from `N` to `p`, `o`, `s`, `l`, or `r`.
 #[derive(Clone)]
 struct Region {
-    pool: ShieldedProtocol,
+    pool: ShieldedPool,
     node: Node,
     l: Option<Node>,
     r: Option<Node>,
@@ -579,7 +579,7 @@ struct Region {
 
 impl Region {
     fn get<H: Clone + HashSer>(
-        pool: ShieldedProtocol,
+        pool: ShieldedPool,
         node_fetcher: NodeFetcher<'_, H>,
         address: Address,
     ) -> Result<Option<Self>, ShardTreeError<zcash_client_sqlite::wallet::commitment_tree::Error>>
@@ -663,9 +663,9 @@ impl Region {
     fn render(&self) -> impl Widget + use<'_> {
         Canvas::default()
             .block(Block::bordered().title(match self.pool {
-                ShieldedProtocol::Sapling => "Sapling tree",
-                ShieldedProtocol::Orchard => "Orchard tree",
-                ShieldedProtocol::Ironwood => "Ironwood tree",
+                ShieldedPool::Sapling => "Sapling tree",
+                ShieldedPool::Orchard => "Orchard tree",
+                ShieldedPool::Ironwood => "Ironwood tree",
             }))
             .x_bounds([-90.0, 90.0])
             .y_bounds([-30.0, 50.0])

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,9 +101,11 @@ fn init_wallet_config<P: AsRef<Path>>(
         mnemonic,
         network: Some(network.name().to_string()),
         birthday: Some(u32::from(birthday)),
+        // Persisted verbatim from what the operator's file stated, so an
+        // explicit "never" and an absent key survive distinctly.
         #[cfg(feature = "regtest_support")]
         activation_heights: match network {
-            Network::Regtest(local) => Some(ActivationHeights::from_local_network(local)),
+            Network::Regtest(heights) => Some(heights),
             _ => None,
         },
     };
@@ -143,12 +145,13 @@ impl WalletConfig {
         // persisted at `init` so this command agrees with the wallet's chain.
         #[cfg(feature = "regtest_support")]
         let network = match network {
-            Network::Regtest(_) => Network::Regtest(
-                config
+            Network::Regtest(_) => {
+                let heights = config
                     .activation_heights
-                    .ok_or(error::Error::InvalidKeysFile)?
-                    .to_local_network(),
-            ),
+                    .ok_or(error::Error::InvalidKeysFile)?;
+                heights.warn_on_implicitly_inactive("wallet config [activation_heights]");
+                Network::Regtest(heights)
+            }
             other => other,
         };
 
@@ -253,29 +256,35 @@ mod tests {
 
         let heights: ActivationHeights = toml::from_str(
             "overwinter = 1\nsapling = 1\nblossom = 1\nheartwood = 1\ncanopy = 1\n\
-             nu5 = 2\nnu6 = 2\nnu6_1 = 5\n",
+             nu5 = 2\nnu6 = 2\nnu6_1 = 5\nnu6_2 = \"never\"\n",
         )
         .unwrap();
-        let network = Network::Regtest(heights.to_local_network());
+        let network = Network::Regtest(heights);
 
         WalletConfig::init_without_mnemonic(Some(&dir), BlockHeight::from_u32(0), network).unwrap();
 
-        // The persisted file records the heights as a table.
+        // The persisted file records the heights as a table, verbatim: the
+        // explicit "never" survives and the absent nu6_3 stays absent.
         let keys_toml = fs::read_to_string(Path::new(&dir).join(KEYS_FILE)).unwrap();
         assert!(keys_toml.contains("[activation_heights]"), "{keys_toml}");
+        assert!(keys_toml.contains("nu6_2 = \"never\""), "{keys_toml}");
+        assert!(!keys_toml.contains("nu6_3"), "{keys_toml}");
 
         let reloaded = WalletConfig::read(Some(&dir)).unwrap();
         match reloaded.network {
-            Network::Regtest(local) => {
+            net @ Network::Regtest(heights) => {
                 assert_eq!(
-                    local.activation_height(NetworkUpgrade::Nu5),
+                    net.activation_height(NetworkUpgrade::Nu5),
                     Some(BlockHeight::from_u32(2))
                 );
                 assert_eq!(
-                    local.activation_height(NetworkUpgrade::Nu6_1),
+                    net.activation_height(NetworkUpgrade::Nu6_1),
                     Some(BlockHeight::from_u32(5))
                 );
-                assert_eq!(local.activation_height(NetworkUpgrade::Nu6_2), None);
+                assert_eq!(net.activation_height(NetworkUpgrade::Nu6_2), None);
+                assert_eq!(net.activation_height(NetworkUpgrade::Nu6_3), None);
+                assert_eq!(heights.nu6_2, Some(crate::data::HeightSetting::Never));
+                assert_eq!(heights.nu6_3, None);
             }
             other => panic!("expected regtest, got {other:?}"),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -291,4 +291,88 @@ mod tests {
 
         fs::remove_dir_all(&dir).unwrap();
     }
+
+    /// Regression: a `keys.toml` persisted by a pre-NU6.3 binary (integer
+    /// heights, no `nu6_3` key) must keep loading, with the same consensus
+    /// view it had under that binary; the absent `nu6_3` reads as inactive.
+    #[test]
+    fn legacy_keys_toml_without_nu6_3_loads() {
+        let dir = std::env::temp_dir().join(format!(
+            "zcash-devtool-cfg-legacy-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        // Verbatim shape of a wallet config written before NU6.3 support.
+        fs::write(
+            dir.join(KEYS_FILE),
+            "network = \"regtest\"\n\
+             birthday = 0\n\
+             \n\
+             [activation_heights]\n\
+             overwinter = 1\n\
+             sapling = 1\n\
+             blossom = 1\n\
+             heartwood = 1\n\
+             canopy = 1\n\
+             nu5 = 2\n\
+             nu6 = 2\n\
+             nu6_1 = 2\n\
+             nu6_2 = 2\n",
+        )
+        .unwrap();
+
+        let config = WalletConfig::read(Some(&dir)).unwrap();
+        let net = config.network();
+        assert_eq!(
+            net.activation_height(NetworkUpgrade::Nu6_2),
+            Some(BlockHeight::from_u32(2))
+        );
+        assert_eq!(net.activation_height(NetworkUpgrade::Nu6_3), None);
+        assert_eq!(config.birthday(), BlockHeight::from_u32(0));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Regression: a regtest wallet config with no `[activation_heights]`
+    /// table at all is still rejected outright, as before the upgrade.
+    #[test]
+    fn regtest_keys_toml_missing_heights_table_still_errors() {
+        let dir = std::env::temp_dir().join(format!(
+            "zcash-devtool-cfg-noheights-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        fs::write(dir.join(KEYS_FILE), "network = \"regtest\"\nbirthday = 0\n").unwrap();
+        assert!(WalletConfig::read(Some(&dir)).is_err());
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Regression: non-regtest wallet configs never carried activation
+    /// heights and must keep loading without them, defaulting the birthday
+    /// to the network's Sapling activation height when unset.
+    #[test]
+    fn test_network_keys_toml_loads_without_heights() {
+        let dir = std::env::temp_dir().join(format!(
+            "zcash-devtool-cfg-testnet-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        fs::write(dir.join(KEYS_FILE), "network = \"test\"\n").unwrap();
+        let config = WalletConfig::read(Some(&dir)).unwrap();
+        assert_eq!(
+            Some(config.birthday()),
+            config
+                .network()
+                .activation_height(consensus::NetworkUpgrade::Sapling)
+        );
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -26,9 +26,12 @@ pub(crate) enum Network {
     Main,
     /// Regtest, carrying the caller-chosen activation heights. These are
     /// fixed at `init` (from `--activation-heights`) and persisted in the
-    /// wallet config so later commands agree.
+    /// wallet config so later commands agree. The raw [`ActivationHeights`]
+    /// are kept (rather than a [`LocalNetwork`]) so persistence is verbatim:
+    /// an explicit `"never"` and an absent key both deactivate an upgrade
+    /// but must survive the round-trip distinctly.
     #[cfg(feature = "regtest_support")]
-    Regtest(LocalNetwork),
+    Regtest(ActivationHeights),
 }
 
 impl Network {
@@ -74,47 +77,94 @@ impl Network {
 /// validator's makes the validator reject transactions built while the tip
 /// is inside the drifted window.
 #[cfg(feature = "regtest_support")]
-const DEFAULT_REGTEST: LocalNetwork = LocalNetwork {
-    overwinter: Some(BlockHeight::from_u32(1)),
-    sapling: Some(BlockHeight::from_u32(1)),
-    blossom: Some(BlockHeight::from_u32(1)),
-    heartwood: Some(BlockHeight::from_u32(1)),
-    canopy: Some(BlockHeight::from_u32(1)),
-    nu5: Some(BlockHeight::from_u32(2)),
-    nu6: Some(BlockHeight::from_u32(2)),
-    nu6_1: Some(BlockHeight::from_u32(2)),
-    nu6_2: Some(BlockHeight::from_u32(2)),
+const DEFAULT_REGTEST: ActivationHeights = ActivationHeights {
+    overwinter: Some(HeightSetting::At(1)),
+    sapling: Some(HeightSetting::At(1)),
+    blossom: Some(HeightSetting::At(1)),
+    heartwood: Some(HeightSetting::At(1)),
+    canopy: Some(HeightSetting::At(1)),
+    nu5: Some(HeightSetting::At(2)),
+    nu6: Some(HeightSetting::At(2)),
+    nu6_1: Some(HeightSetting::At(2)),
+    nu6_2: Some(HeightSetting::At(2)),
+    nu6_3: Some(HeightSetting::At(2)),
     #[cfg(zcash_unstable = "nu7")]
-    nu7: Some(BlockHeight::from_u32(2)),
+    nu7: Some(HeightSetting::At(2)),
 };
 
+/// One entry in the activation-heights schema: activate at a block height, or
+/// `"never"` — the operator's explicit statement that the upgrade does not
+/// exist on this chain. A key that is absent entirely (`None` around this
+/// type) also deactivates the upgrade, but is warned about on load, since
+/// absence may only mean the file predates this tool's knowledge of the
+/// upgrade.
+#[cfg(feature = "regtest_support")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HeightSetting {
+    At(u32),
+    Never,
+}
+
+#[cfg(feature = "regtest_support")]
+impl serde::Serialize for HeightSetting {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            HeightSetting::At(height) => serializer.serialize_u32(*height),
+            HeightSetting::Never => serializer.serialize_str("never"),
+        }
+    }
+}
+
+#[cfg(feature = "regtest_support")]
+impl<'de> serde::Deserialize<'de> for HeightSetting {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Height(u32),
+            Word(String),
+        }
+        match Raw::deserialize(deserializer)? {
+            Raw::Height(height) => Ok(HeightSetting::At(height)),
+            Raw::Word(word) if word == "never" => Ok(HeightSetting::Never),
+            Raw::Word(word) => Err(serde::de::Error::custom(format!(
+                "invalid activation height {word:?}: expected a block height or \"never\""
+            ))),
+        }
+    }
+}
+
 /// A `LocalNetwork`-shaped set of regtest activation heights, one optional
-/// height per network upgrade (a missing entry means "not active"). This is
-/// the schema of the `--activation-heights` TOML file and of the
-/// `[activation_heights]` table persisted in the wallet config; the two share
-/// this type so a wallet's heights round-trip from the file the operator
-/// commits to revision control.
+/// [`HeightSetting`] per network upgrade (a missing entry means "not
+/// active"). This is the schema of the `--activation-heights` TOML file and
+/// of the `[activation_heights]` table persisted in the wallet config; the
+/// two share this type so a wallet's heights round-trip verbatim from the
+/// file the operator commits to revision control.
 #[cfg(feature = "regtest_support")]
 #[derive(Clone, Copy, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub(crate) struct ActivationHeights {
-    pub(crate) overwinter: Option<u32>,
-    pub(crate) sapling: Option<u32>,
-    pub(crate) blossom: Option<u32>,
-    pub(crate) heartwood: Option<u32>,
-    pub(crate) canopy: Option<u32>,
-    pub(crate) nu5: Option<u32>,
-    pub(crate) nu6: Option<u32>,
-    pub(crate) nu6_1: Option<u32>,
-    pub(crate) nu6_2: Option<u32>,
+    pub(crate) overwinter: Option<HeightSetting>,
+    pub(crate) sapling: Option<HeightSetting>,
+    pub(crate) blossom: Option<HeightSetting>,
+    pub(crate) heartwood: Option<HeightSetting>,
+    pub(crate) canopy: Option<HeightSetting>,
+    pub(crate) nu5: Option<HeightSetting>,
+    pub(crate) nu6: Option<HeightSetting>,
+    pub(crate) nu6_1: Option<HeightSetting>,
+    pub(crate) nu6_2: Option<HeightSetting>,
+    pub(crate) nu6_3: Option<HeightSetting>,
     #[cfg(zcash_unstable = "nu7")]
-    pub(crate) nu7: Option<u32>,
+    pub(crate) nu7: Option<HeightSetting>,
 }
 
 #[cfg(feature = "regtest_support")]
 impl ActivationHeights {
     pub(crate) fn to_local_network(self) -> LocalNetwork {
-        let h = |v: Option<u32>| v.map(BlockHeight::from_u32);
+        let h = |v: Option<HeightSetting>| match v {
+            Some(HeightSetting::At(height)) => Some(BlockHeight::from_u32(height)),
+            Some(HeightSetting::Never) | None => None,
+        };
         LocalNetwork {
             overwinter: h(self.overwinter),
             sapling: h(self.sapling),
@@ -125,37 +175,55 @@ impl ActivationHeights {
             nu6: h(self.nu6),
             nu6_1: h(self.nu6_1),
             nu6_2: h(self.nu6_2),
+            nu6_3: h(self.nu6_3),
             #[cfg(zcash_unstable = "nu7")]
             nu7: h(self.nu7),
         }
     }
 
-    pub(crate) fn from_local_network(local: LocalNetwork) -> Self {
-        let h = |v: Option<BlockHeight>| v.map(u32::from);
-        Self {
-            overwinter: h(local.overwinter),
-            sapling: h(local.sapling),
-            blossom: h(local.blossom),
-            heartwood: h(local.heartwood),
-            canopy: h(local.canopy),
-            nu5: h(local.nu5),
-            nu6: h(local.nu6),
-            nu6_1: h(local.nu6_1),
-            nu6_2: h(local.nu6_2),
+    /// Warn about upgrades this binary knows that `self` leaves implicitly
+    /// inactive (key absent). Explicit entries — a height or `"never"` — are
+    /// silent.
+    pub(crate) fn warn_on_implicitly_inactive(&self, source: &str) {
+        let absent: Vec<&str> = [
+            ("overwinter", self.overwinter),
+            ("sapling", self.sapling),
+            ("blossom", self.blossom),
+            ("heartwood", self.heartwood),
+            ("canopy", self.canopy),
+            ("nu5", self.nu5),
+            ("nu6", self.nu6),
+            ("nu6_1", self.nu6_1),
+            ("nu6_2", self.nu6_2),
+            ("nu6_3", self.nu6_3),
             #[cfg(zcash_unstable = "nu7")]
-            nu7: h(local.nu7),
+            ("nu7", self.nu7),
+        ]
+        .iter()
+        .filter(|(_, setting)| setting.is_none())
+        .map(|(key, _)| *key)
+        .collect();
+        if !absent.is_empty() {
+            tracing::warn!(
+                "{source} does not mention {}; treating as inactive. State a height or \
+                 \"never\" explicitly to silence this warning, and ensure the validator's \
+                 configuration agrees.",
+                absent.join(", ")
+            );
         }
     }
 }
 
-/// Load a `--activation-heights` TOML file into a `LocalNetwork`.
+/// Load a `--activation-heights` TOML file, warning about upgrades the file
+/// leaves implicitly inactive.
 #[cfg(feature = "regtest_support")]
-pub(crate) fn load_activation_heights(path: &Path) -> anyhow::Result<LocalNetwork> {
+pub(crate) fn load_activation_heights(path: &Path) -> anyhow::Result<ActivationHeights> {
     let contents = std::fs::read_to_string(path)
         .map_err(|e| anyhow::anyhow!("reading activation-heights file {path:?}: {e}"))?;
     let heights: ActivationHeights = toml::from_str(&contents)
         .map_err(|e| anyhow::anyhow!("parsing activation-heights file {path:?}: {e}"))?;
-    Ok(heights.to_local_network())
+    heights.warn_on_implicitly_inactive(&format!("activation-heights file {path:?}"));
+    Ok(heights)
 }
 
 impl Parameters for Network {
@@ -164,7 +232,7 @@ impl Parameters for Network {
             Network::Test => consensus::Network::TestNetwork.network_type(),
             Network::Main => consensus::Network::MainNetwork.network_type(),
             #[cfg(feature = "regtest_support")]
-            Network::Regtest(local) => local.network_type(),
+            Network::Regtest(heights) => heights.to_local_network().network_type(),
         }
     }
 
@@ -173,7 +241,7 @@ impl Parameters for Network {
             Network::Test => consensus::Network::TestNetwork.activation_height(nu),
             Network::Main => consensus::Network::MainNetwork.activation_height(nu),
             #[cfg(feature = "regtest_support")]
-            Network::Regtest(local) => local.activation_height(nu),
+            Network::Regtest(heights) => heights.to_local_network().activation_height(nu),
         }
     }
 }
@@ -240,7 +308,8 @@ mod tests {
 
     #[test]
     fn activation_heights_toml_maps_to_local_network() {
-        // A missing key (here nu6_2) means the upgrade is inactive.
+        // An explicit "never" (here nu6_2) and a missing key (here nu6_3)
+        // both leave the upgrade inactive on the resulting chain.
         let toml = "\
 overwinter = 1
 sapling = 1
@@ -250,10 +319,10 @@ canopy = 1
 nu5 = 2
 nu6 = 2
 nu6_1 = 2
+nu6_2 = \"never\"
 ";
         let heights: ActivationHeights = toml::from_str(toml).unwrap();
-        let local = heights.to_local_network();
-        let net = Network::Regtest(local);
+        let net = Network::Regtest(heights);
 
         assert_eq!(
             net.activation_height(NetworkUpgrade::Sapling),
@@ -264,15 +333,26 @@ nu6_1 = 2
             Some(BlockHeight::from_u32(2))
         );
         assert_eq!(net.activation_height(NetworkUpgrade::Nu6_2), None);
+        assert_eq!(net.activation_height(NetworkUpgrade::Nu6_3), None);
     }
 
     #[test]
-    fn activation_heights_round_trip_through_local_network() {
-        let original: ActivationHeights = toml::from_str("nu5 = 7\nnu6 = 9\n").unwrap();
-        let restored = ActivationHeights::from_local_network(original.to_local_network());
-        // Restoring from the LocalNetwork preserves set and unset upgrades.
-        assert_eq!(restored.nu5, Some(7));
-        assert_eq!(restored.nu6, Some(9));
-        assert_eq!(restored.sapling, None);
+    fn activation_heights_round_trip_verbatim() {
+        let original: ActivationHeights = toml::from_str("nu5 = 7\nnu6 = \"never\"\n").unwrap();
+        assert_eq!(original.nu5, Some(HeightSetting::At(7)));
+        assert_eq!(original.nu6, Some(HeightSetting::Never));
+
+        let reserialized = toml::to_string(&original).unwrap();
+        let restored: ActivationHeights = toml::from_str(&reserialized).unwrap();
+        assert_eq!(restored.nu5, Some(HeightSetting::At(7)));
+        assert_eq!(restored.nu6, Some(HeightSetting::Never));
+        // An absent key stays absent — implicitly inactive is preserved, not
+        // laundered into an explicit "never".
+        assert_eq!(restored.nu6_3, None);
+    }
+
+    #[test]
+    fn activation_heights_reject_words_other_than_never() {
+        assert!(toml::from_str::<ActivationHeights>("nu5 = \"nevr\"\n").is_err());
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -160,6 +160,10 @@ pub(crate) struct ActivationHeights {
 
 #[cfg(feature = "regtest_support")]
 impl ActivationHeights {
+    /// Consensus queries deliberately route through [`LocalNetwork`] rather
+    /// than a local `Parameters` impl (see `docs/adr/0002`): its exhaustive
+    /// struct literal is the compile-time tripwire that surfaces new network
+    /// upgrades at dependency bumps.
     pub(crate) fn to_local_network(self) -> LocalNetwork {
         let h = |v: Option<HeightSetting>| match v {
             Some(HeightSetting::At(height)) => Some(BlockHeight::from_u32(height)),

--- a/src/data.rs
+++ b/src/data.rs
@@ -355,4 +355,89 @@ nu6_2 = \"never\"
     fn activation_heights_reject_words_other_than_never() {
         assert!(toml::from_str::<ActivationHeights>("nu5 = \"nevr\"\n").is_err());
     }
+
+    /// Regression: a heights file written before NU6.3 support (integer
+    /// values only, no `nu6_3` key) must keep parsing, with the identical
+    /// consensus view it had under the old binary.
+    #[test]
+    fn legacy_integer_only_heights_file_still_parses() {
+        // Verbatim shape of a pre-NU6.3 operator file.
+        let legacy = "\
+overwinter = 1
+sapling = 1
+blossom = 1
+heartwood = 1
+canopy = 1
+nu5 = 2
+nu6 = 2
+nu6_1 = 2
+nu6_2 = 2
+";
+        let heights: ActivationHeights = toml::from_str(legacy).unwrap();
+        let net = Network::Regtest(heights);
+
+        for (nu, expected) in [
+            (NetworkUpgrade::Overwinter, 1),
+            (NetworkUpgrade::Sapling, 1),
+            (NetworkUpgrade::Blossom, 1),
+            (NetworkUpgrade::Heartwood, 1),
+            (NetworkUpgrade::Canopy, 1),
+            (NetworkUpgrade::Nu5, 2),
+            (NetworkUpgrade::Nu6, 2),
+            (NetworkUpgrade::Nu6_1, 2),
+            (NetworkUpgrade::Nu6_2, 2),
+        ] {
+            assert_eq!(
+                net.activation_height(nu),
+                Some(BlockHeight::from_u32(expected)),
+                "{nu:?}"
+            );
+        }
+        assert_eq!(net.activation_height(NetworkUpgrade::Nu6_3), None);
+    }
+
+    /// Regression: heights that use no `"never"` entries must serialize in
+    /// the legacy integer-only format, so a wallet config that predates
+    /// NU6.3 support re-persists byte-compatibly and remains readable by
+    /// older binaries (whose `deny_unknown_fields` would reject new keys).
+    #[test]
+    fn integer_heights_serialize_in_legacy_format() {
+        let heights: ActivationHeights = toml::from_str("nu5 = 2\nnu6 = 2\n").unwrap();
+        let serialized = toml::to_string(&heights).unwrap();
+        assert_eq!(serialized, "nu5 = 2\nnu6 = 2\n");
+    }
+
+    /// Regression: unknown keys are still rejected, as before the upgrade.
+    #[test]
+    fn unknown_upgrade_keys_still_rejected() {
+        assert!(toml::from_str::<ActivationHeights>("nu9 = 1\n").is_err());
+    }
+
+    /// Regression: the built-in fallback heights still match the
+    /// `zcash_local_net` wallet-funding zebrad fixture (pre-NU5 at 1,
+    /// everything NU5+ at 2) for all upgrades that predate NU6.3 support,
+    /// and the network still reports itself as regtest.
+    #[test]
+    fn default_regtest_fallback_heights_unchanged() {
+        let net = Network::parse("regtest").unwrap();
+
+        assert_eq!(net.network_type(), consensus::NetworkType::Regtest);
+        for (nu, expected) in [
+            (NetworkUpgrade::Overwinter, 1),
+            (NetworkUpgrade::Sapling, 1),
+            (NetworkUpgrade::Blossom, 1),
+            (NetworkUpgrade::Heartwood, 1),
+            (NetworkUpgrade::Canopy, 1),
+            (NetworkUpgrade::Nu5, 2),
+            (NetworkUpgrade::Nu6, 2),
+            (NetworkUpgrade::Nu6_1, 2),
+            (NetworkUpgrade::Nu6_2, 2),
+        ] {
+            assert_eq!(
+                net.activation_height(nu),
+                Some(BlockHeight::from_u32(expected)),
+                "{nu:?}"
+            );
+        }
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,9 @@ pub(crate) type WalletErrorT = WalletError<
     ReceivedNoteId,
 >;
 
+// `propose_send_max_transfer` returns `ProposeSendMaxErrT`, whose
+// input-selection error slot is `BalanceError` (not `GreedyInputSelectorError`
+// like the greedy `propose_transfer`/`propose_shielding` paths).
 pub(crate) type SendMaxErrorT = WalletError<
     SqliteClientError,
     commitment_tree::Error,

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ fn main() -> Result<(), anyhow::Error> {
                 commands::wallet::Command::ListAccounts(command) => command.run(wallet_dir),
                 commands::wallet::Command::GenerateAddress(command) => command.run(wallet_dir),
                 commands::wallet::Command::ListAddresses(command) => command.run(wallet_dir),
+                commands::wallet::Command::DeriveAddress(command) => command.run(),
                 commands::wallet::Command::DerivePath(command) => command.run(wallet_dir),
                 commands::wallet::Command::ListTx(command) => command.run(wallet_dir),
                 commands::wallet::Command::ListUnspent(command) => command.run(wallet_dir),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,10 +1,22 @@
+use zcash_protocol::consensus::NetworkType;
 use zcash_protocol::value::ZatBalance;
 
 pub(crate) mod proposal;
 
 const COIN: u64 = 1_0000_0000;
 
-pub(crate) fn format_zec(value: impl TryInto<ZatBalance>) -> String {
+/// The display ticker for amounts on the given network, matching the
+/// zcashd/zebra convention: `ZEC` on mainnet, `TAZ` on testnet, `REG` on
+/// regtest.
+pub(crate) fn ticker(network: NetworkType) -> &'static str {
+    match network {
+        NetworkType::Main => "ZEC",
+        NetworkType::Test => "TAZ",
+        NetworkType::Regtest => "REG",
+    }
+}
+
+pub(crate) fn format_zec(value: impl TryInto<ZatBalance>, network: NetworkType) -> String {
     let value = i64::from(
         value
             .try_into()
@@ -19,5 +31,5 @@ pub(crate) fn format_zec(value: impl TryInto<ZatBalance>) -> String {
     } else {
         abs_zec as i64
     };
-    format!("{zec:3}.{frac:08} ZEC")
+    format!("{zec:3}.{frac:08} {}", ticker(network))
 }

--- a/src/ui/proposal.rs
+++ b/src/ui/proposal.rs
@@ -9,7 +9,7 @@ use zcash_client_backend::{
 };
 use zcash_protocol::{
     PoolType,
-    consensus::Parameters,
+    consensus::{NetworkType, Parameters},
     memo::{Memo, MemoBytes},
 };
 use zip321::TransactionRequest;
@@ -30,22 +30,32 @@ pub(crate) fn print_proposal<P: Parameters, FeeRuleT: Debug, NoteRef>(
     println!("  Fee rule: {:?}", proposal.fee_rule());
     let steps = proposal.steps();
     println!("  Steps ({}):", steps.len());
+    let net = params.network_type();
     for (i, step) in steps.iter().enumerate() {
-        print_step(i, step, params);
+        print_step(i, step, params, net);
     }
 }
 
-fn print_step<P: Parameters, NoteRef>(index: usize, step: &Step<NoteRef>, params: &P) {
+fn print_step<P: Parameters, NoteRef>(
+    index: usize,
+    step: &Step<NoteRef>,
+    params: &P,
+    net: NetworkType,
+) {
     println!("    Step {index}:");
     println!("      Shielding: {}", step.is_shielding());
-    print_payments(step.transaction_request(), step.payment_pools());
-    print_transparent_inputs(step.transparent_inputs(), params);
-    print_shielded_inputs(step.shielded_inputs());
+    print_payments(step.transaction_request(), step.payment_pools(), net);
+    print_transparent_inputs(step.transparent_inputs(), params, net);
+    print_shielded_inputs(step.shielded_inputs(), net);
     print_prior_step_inputs(step.prior_step_inputs());
-    print_balance(step.balance());
+    print_balance(step.balance(), net);
 }
 
-fn print_payments(request: &TransactionRequest, payment_pools: &BTreeMap<usize, PoolType>) {
+fn print_payments(
+    request: &TransactionRequest,
+    payment_pools: &BTreeMap<usize, PoolType>,
+    net: NetworkType,
+) {
     let payments = request.payments();
     println!("      Payments ({}):", payments.len());
     for (idx, payment) in payments {
@@ -58,7 +68,7 @@ fn print_payments(request: &TransactionRequest, payment_pools: &BTreeMap<usize, 
             "            Amount: {}",
             payment
                 .amount()
-                .map(format_zec)
+                .map(|v| format_zec(v, net))
                 .unwrap_or_else(|| "<unspecified>".to_owned()),
         );
         println!("            Pool: {pool}");
@@ -77,7 +87,11 @@ fn print_payments(request: &TransactionRequest, payment_pools: &BTreeMap<usize, 
     }
 }
 
-fn print_transparent_inputs<P: Parameters, A>(inputs: &[WalletTransparentOutput<A>], params: &P) {
+fn print_transparent_inputs<P: Parameters, A>(
+    inputs: &[WalletTransparentOutput<A>],
+    params: &P,
+    net: NetworkType,
+) {
     if inputs.is_empty() {
         return;
     }
@@ -88,13 +102,13 @@ fn print_transparent_inputs<P: Parameters, A>(inputs: &[WalletTransparentOutput<
             "        - {}:{}  {}  -> {}",
             outpoint.txid(),
             outpoint.n(),
-            format_zec(input.value()),
+            format_zec(input.value(), net),
             input.recipient_address().encode(params),
         );
     }
 }
 
-fn print_shielded_inputs<NoteRef>(inputs: Option<&ShieldedInputs<NoteRef>>) {
+fn print_shielded_inputs<NoteRef>(inputs: Option<&ShieldedInputs<NoteRef>>, net: NetworkType) {
     let Some(inputs) = inputs else {
         return;
     };
@@ -105,11 +119,11 @@ fn print_shielded_inputs<NoteRef>(inputs: Option<&ShieldedInputs<NoteRef>>) {
         u32::from(inputs.anchor_height()),
     );
     for received in notes.iter() {
-        print_received_note(received);
+        print_received_note(received, net);
     }
 }
 
-fn print_received_note<NoteRef>(received: &ReceivedNote<NoteRef, Note>) {
+fn print_received_note<NoteRef>(received: &ReceivedNote<NoteRef, Note>, net: NetworkType) {
     let pool = match received.note() {
         Note::Sapling(_) => "Sapling",
         Note::Orchard(_) => "Orchard",
@@ -118,7 +132,7 @@ fn print_received_note<NoteRef>(received: &ReceivedNote<NoteRef, Note>) {
         "        - {pool} {}:{}  {}",
         received.txid(),
         received.output_index(),
-        format_zec(received.note().value()),
+        format_zec(received.note().value(), net),
     );
 }
 
@@ -136,14 +150,14 @@ fn print_prior_step_inputs(refs: &[StepOutput]) {
     }
 }
 
-fn print_balance(balance: &TransactionBalance) {
+fn print_balance(balance: &TransactionBalance, net: NetworkType) {
     let changes = balance.proposed_change();
     println!("      Change outputs ({}):", changes.len());
     for change in changes {
         let mut line = format!(
             "        - {} {}",
             change.output_pool(),
-            format_zec(change.value()),
+            format_zec(change.value(), net),
         );
         if change.is_ephemeral() {
             line.push_str(" [ephemeral]");
@@ -153,7 +167,7 @@ fn print_balance(balance: &TransactionBalance) {
             print_memo(12, memo);
         }
     }
-    println!("      Fee: {}", format_zec(balance.fee_required()));
+    println!("      Fee: {}", format_zec(balance.fee_required(), net));
 }
 
 fn print_memo(indent: usize, memo: &MemoBytes) {


### PR DESCRIPTION
**Stacked on #205** — this branch is based on `support_NU6_3`, so the diff currently includes #205's commits. Only the **top four commits** are new here; once #205 merges, this PR's diff shrinks to just them.

Ports the parts of [`zecrocks/zcash-devtool@ironwood-valar`](https://github.com/zecrocks/zcash-devtool/tree/ironwood-valar) that work against librustzcash **main** (everything here compiles with the existing pin; nothing requires the unmerged Ironwood RC line):

- **`wallet derive-address`** — offline derivation of a mnemonic's default unified + transparent addresses (no wallet dir, no server), so a regtest harness can learn the funder's coinbase `miner_address` before the chain exists. Smoke-tested against the BIP-39 test vector.
- **Network-aware tickers** — amounts display as `ZEC`/`TAZ`/`REG` per network (ZIP-321 requests are network-agnostic and default to `ZEC`).
- **Ironwood readiness** — `pczt prove` only builds the (expensive) proving key when a bundle needs a proof and creates Ironwood proofs when an Ironwood bundle is present (keeping the consensus-branch-derived circuit version from #205 rather than the fork's hardcoded `PostNu6_3`); `wallet send --tx-version 6`; `list-tx` decodes pool code 4 as Ironwood.
- **`doc/ironwood.md`** — NU6.3/V6 explainer adapted to this repo's pin: per-network activation, the regtest walkthrough with the height-or-`"never"` schema, the cross-component heights invariant, and companion node/indexer requirements.

Deliberately **not** ported: wallet-level Ironwood balances/spends (`ironwood_balance()` exists only on librustzcash's unmerged RC line) and the fork's hardcoded prover/verifier circuit versions.

All ported commits credit Blake Emerson (zecrocks) as co-author. Verified: `cargo check` on default/`regtest_support`/`tui,qr`/`pczt-qr` feature sets, `clippy --all-targets --features regtest_support -- -D warnings` clean, 11/11 tests, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)