### PR TITLE
Address review feedback on #217 (batch-signing and migration commands)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ uuid = "1"
 # Zcash
 #
 # NOTE: zcash_client_backend/zcash_client_sqlite/pczt/zip321 version reqs
-# below are pinned to the exact prerelease versions published on Danny
-# Willems' feat/pool-migration-sqlite branch (see [patch.crates-io] below) —
-# these are ahead of the last crates.io releases. If the patch rev changes,
+# below are pinned to the exact prerelease versions on the librustzcash
+# main revision in [patch.crates-io] below — these are ahead of the last
+# crates.io releases. If the patch rev changes,
 # re-check these against the new rev's Cargo.toml files, or Cargo will
 # silently fall back to stale crates.io versions for the unsatisfied ones
 # and duplicate half the dependency graph (as happened here).

--- a/src/commands/migration.rs
+++ b/src/commands/migration.rs
@@ -19,8 +19,8 @@ pub(crate) enum Command {
     /// Show the in-progress migration's status and what to do next.
     Status(status::Command),
 
-    /// Advance an in-progress migration: build and sign the next ready preparation layer or the
-    /// transfers, as far as possible. Stops (without erroring) at the first transaction that's
-    /// ready to prove and broadcast, since that step isn't implemented yet.
+    /// Advance an in-progress migration: prove the next transaction whose deferred anchor is
+    /// ready. Stops (without erroring) at the first transaction that's ready to broadcast or
+    /// needs rebuilding after expiry, since those steps aren't implemented yet.
     Advance(advance::Command),
 }

--- a/src/commands/migration/advance.rs
+++ b/src/commands/migration/advance.rs
@@ -42,8 +42,9 @@ impl Command {
         // Every transaction is already built and signed at commit time now (one signing phase),
         // so there is nothing left for `advance` to build. It proves transactions whose deferred
         // anchor is ready (installing it and the spend witnesses through the PCZT `Updater` role,
-        // ZIP 374) and orders broadcasts against the LIVE chain tip (`migration status` uses a
-        // synthetic height instead, since it doesn't need a synced wallet just to display state).
+        // ZIP 374) and orders broadcasts against the LIVE chain tip, same as `migration status`
+        // -- anything derived from the migration's own schedule would make transactions look
+        // ready regardless of the real chain.
         let mut wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
         let account = select_account(&wallet_db, self.account_id)?;
         let fvk = account

--- a/src/commands/migration/commit.rs
+++ b/src/commands/migration/commit.rs
@@ -95,6 +95,27 @@ impl Command {
             other => anyhow!("{other}"),
         };
 
+        // Fail fast on a leftover output dir BEFORE building anything: `fs::rename` below can't
+        // replace a non-empty directory (so a re-run would die only after all the build work),
+        // and a leftover-but-empty dir would let a previous run's stale `<id>.pczt` files mix
+        // with this run's in the suggested `*.pczt` glob.
+        let external_out_dir = if self.external {
+            let out_dir = db_path
+                .parent()
+                .ok_or_else(|| anyhow!("wallet database path has no parent directory"))?
+                .join("unsigned-pczts");
+            if out_dir.exists() {
+                return Err(anyhow!(
+                    "{} already exists (from a previous `migration commit --external`?); move \
+                     or delete it first so this run's PCZTs can't mix with stale ones",
+                    out_dir.display()
+                ));
+            }
+            Some(out_dir)
+        } else {
+            None
+        };
+
         let (state, unsigned) = if self.external {
             build_preparation_unsigned(&params, target_height, &mut migration, &plan, &mut rng)
                 .map_err(map_commit_err)?
@@ -104,26 +125,30 @@ impl Command {
             (state, Vec::new())
         };
 
-        if self.external {
-            let out_dir = db_path
-                .parent()
-                .ok_or_else(|| anyhow!("wallet database path has no parent directory"))?
-                .join("unsigned-pczts");
+        if let Some(out_dir) = &external_out_dir {
             let staged_out_dir =
                 out_dir.with_file_name(format!(".unsigned-pczts-{}.tmp", Uuid::new_v4()));
             fs::create_dir(&staged_out_dir)?;
             println!("{} unsigned PCZT(s) for external signing:", unsigned.len());
-            for tx in unsigned {
-                let (id, pczt) = tx.into_parts();
-                let path = staged_out_dir.join(format!("{}.pczt", u32::from(id)));
-                fs::write(&path, &pczt)?;
+            let write_all = || -> anyhow::Result<()> {
+                for tx in unsigned {
+                    let (id, pczt) = tx.into_parts();
+                    let path = staged_out_dir.join(format!("{}.pczt", u32::from(id)));
+                    fs::write(&path, &pczt)?;
+                }
+                // Do not persist a migration that needs external signatures until every PCZT has
+                // been written successfully. Otherwise a full disk or interrupted write can leave
+                // the wallet permanently reporting an in-progress migration whose signing material
+                // does not exist. The staged directory also ensures callers never see a partial set.
+                fs::rename(&staged_out_dir, out_dir)?;
+                Ok(())
+            };
+            if let Err(e) = write_all() {
+                // Best-effort: don't strand the staged temp dir next to the wallet on failure.
+                let _ = fs::remove_dir_all(&staged_out_dir);
+                return Err(e);
             }
-            // Do not persist a migration that needs external signatures until every PCZT has
-            // been written successfully. Otherwise a full disk or interrupted write can leave
-            // the wallet permanently reporting an in-progress migration whose signing material
-            // does not exist. The staged directory also ensures callers never see a partial set.
-            fs::rename(&staged_out_dir, &out_dir)?;
-            for entry in fs::read_dir(&out_dir)? {
+            for entry in fs::read_dir(out_dir)? {
                 println!("  {}", entry?.path().display());
             }
             println!(

--- a/src/commands/pczt/qr.rs
+++ b/src/commands/pczt/qr.rs
@@ -604,6 +604,12 @@ fn decode_batch_sig_result(
 /// Applies a [`BatchSignResponse`]'s signatures onto the original (unredacted) PCZTs, in the
 /// same order as `paths`, and writes each result out -- overwriting in place, or alongside with
 /// `out_suffix` appended to the filename. Shared by `from-qr-batch` and `batch-sign`.
+///
+/// Signatures are applied through the Orchard signer role only. That matches every batch this
+/// tool produces today: an Orchard -> Ironwood migration batch's real spends are all Orchard,
+/// and its Ironwood actions' dummy `spend_auth_sig`s are still intact on the original files
+/// (redaction only ever touched the copies sent over the wire). A future batch carrying real
+/// Ironwood spends would need an Ironwood counterpart here, not silent reuse of this path.
 fn apply_batch_signatures_and_write(
     paths: &[PathBuf],
     pczts: Vec<Pczt>,
@@ -612,7 +618,7 @@ fn apply_batch_signatures_and_write(
 ) -> anyhow::Result<()> {
     if response.signatures().len() != pczts.len() {
         return Err(anyhow!(
-            "Batch sign response has {} PCZT('s) worth of signatures, but {} --pczt file(s) \
+            "Batch sign response has {} PCZT(s) worth of signatures, but {} --pczt file(s) \
              were given -- pass the SAME files, in the SAME order, given when sending the batch",
             response.signatures().len(),
             pczts.len()
@@ -636,8 +642,14 @@ fn apply_batch_signatures_and_write(
             Some(suffix) => PathBuf::from(format!("{}{suffix}", path.display())),
             None => path.clone(),
         };
-        std::fs::write(&out_path, &signed_bytes)
-            .map_err(|e| anyhow!("Failed to write {}: {e}", out_path.display()))?;
+        // Stage-and-rename rather than writing in place: without a suffix, `out_path` IS the
+        // unsigned original, and a crash mid-write would destroy both it and the signed result
+        // -- the only output of a signing session that cost a physical device round trip.
+        let staged_path = PathBuf::from(format!("{}.tmp", out_path.display()));
+        std::fs::write(&staged_path, &signed_bytes)
+            .map_err(|e| anyhow!("Failed to write {}: {e}", staged_path.display()))?;
+        std::fs::rename(&staged_path, &out_path)
+            .map_err(|e| anyhow!("Failed to move signed PCZT to {}: {e}", out_path.display()))?;
         println!("  wrote signed PCZT to {}", out_path.display());
     }
 
@@ -904,9 +916,17 @@ async fn scan_for_ur(
         match &detected_result {
             Ok((_, Some(content))) if content.starts_with(expected_ur_type) => {
                 progress.record(content);
-                decoder
-                    .receive(content)
-                    .map_err(|e| anyhow!("Failed to parse QR code: {:?}", e))?;
+                // A frame of the right UR type can still be rejected by the decoder -- a stale
+                // QR from a previous run, the device looping back to an earlier message, or a
+                // corrupted read that kept the type prefix intact. That's a property of the one
+                // frame, not the scan: record it and keep scanning (same as grid-decode errors
+                // below) rather than aborting a possibly hundreds-of-parts session.
+                if let Err(e) = decoder.receive(content) {
+                    progress.last_status = format!("Rejected QR part: {e:?}");
+                    if no_preview {
+                        eprintln!("Rejected QR part: {e:?}");
+                    }
+                }
             }
             Ok((_, Some(content))) => {
                 progress.last_status = format!("Unexpected UR type: {content}");
@@ -1032,7 +1052,7 @@ fn render_preview(
         .map_or_else(|| "?".to_string(), |t| t.to_string());
     let _ = writeln!(
         out,
-        "QR detected: {}   |   unique parts seen: {}/{total}   |   frames read: {}   |   {}",
+        "QR detected: {}   |   unique parts seen: {}/{total}   |   matching frames read: {}   |   {}",
         if qr_detected {
             "yes"
         } else {
@@ -1049,8 +1069,10 @@ fn render_preview(
 fn convert_buffer_to_image(
     buffer: nokhwa::Buffer,
 ) -> anyhow::Result<image::ImageBuffer<image::Rgb<u8>, Vec<u8>>> {
-    // `scan_camera_format` requests MJPEG, so this is the expected path -- see its doc comment
-    // for why the raw-YUYV path below is unreliable on macOS and MJPEG isn't.
+    // `scan_camera_format` does NOT request MJPEG (see its doc comment for why that was tried
+    // and abandoned on macOS), but nokhwa's negotiator may still hand back an MJPEG stream on
+    // other backends -- decode it via the JPEG decoder rather than falling through to the
+    // raw-YUYV path, which would misread compressed bytes as pixels.
     if buffer.source_frame_format() == FrameFormat::MJPEG {
         return Ok(image::load_from_memory(buffer.buffer())?.to_rgb8());
     }

--- a/src/commands/pczt/qr.rs
+++ b/src/commands/pczt/qr.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::anyhow;
@@ -648,12 +648,40 @@ fn apply_batch_signatures_and_write(
         let staged_path = PathBuf::from(format!("{}.tmp", out_path.display()));
         std::fs::write(&staged_path, &signed_bytes)
             .map_err(|e| anyhow!("Failed to write {}: {e}", staged_path.display()))?;
-        std::fs::rename(&staged_path, &out_path)
+        replace_file(&staged_path, &out_path)
             .map_err(|e| anyhow!("Failed to move signed PCZT to {}: {e}", out_path.display()))?;
         println!("  wrote signed PCZT to {}", out_path.display());
     }
 
     Ok(())
+}
+
+/// Moves `staged` over `dest`, replacing `dest` if it exists. `staged` must be on the same
+/// filesystem as `dest` (the callers stage as `<dest>.tmp`, so it always is).
+///
+/// A plain `std::fs::rename` replaces an existing destination on every supported platform
+/// (on Windows, Rust maps it to a replace-if-exists move rather than C `rename` semantics),
+/// but on Windows that replacement can still fail where Unix would succeed: the destination
+/// being momentarily held open by antivirus/indexing, or carrying the read-only attribute.
+/// If the rename fails while `dest` exists, clear `dest` and retry once. The fallback gives
+/// up crash-atomicity, but `staged` survives any failure, so the signed PCZT is never lost.
+fn replace_file(staged: &Path, dest: &Path) -> std::io::Result<()> {
+    match std::fs::rename(staged, dest) {
+        Ok(()) => Ok(()),
+        Err(_) if dest.exists() => {
+            if let Ok(metadata) = dest.metadata() {
+                let mut permissions = metadata.permissions();
+                if permissions.readonly() {
+                    #[allow(clippy::permissions_set_readonly_false)]
+                    permissions.set_readonly(false);
+                    let _ = std::fs::set_permissions(dest, permissions);
+                }
+            }
+            std::fs::remove_file(dest)?;
+            std::fs::rename(staged, dest)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 const DATA: u8 = 1;
@@ -1173,6 +1201,69 @@ mod tests {
         assert_eq!(progress.total_parts, None);
         assert!(progress.seen_parts.is_empty());
         assert_eq!(progress.last_status, "received part (no sequence info)");
+    }
+
+    /// A scratch directory under the platform temp dir, removed on drop. Unique per test via
+    /// the test name (tests run in one process, so pid alone wouldn't disambiguate them).
+    struct ScratchDir(PathBuf);
+
+    impl ScratchDir {
+        fn new(test_name: &str) -> Self {
+            let dir = std::env::temp_dir()
+                .join(format!("zcash-devtool-{test_name}-{}", std::process::id()));
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+    }
+
+    impl Drop for ScratchDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn replace_file_replaces_an_existing_destination() {
+        let scratch = ScratchDir::new("replace-existing");
+        let staged = scratch.0.join("out.pczt.tmp");
+        let dest = scratch.0.join("out.pczt");
+        std::fs::write(&staged, b"signed").unwrap();
+        std::fs::write(&dest, b"unsigned original").unwrap();
+
+        replace_file(&staged, &dest).unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"signed");
+        assert!(!staged.exists());
+    }
+
+    #[test]
+    fn replace_file_replaces_a_read_only_destination() {
+        let scratch = ScratchDir::new("replace-read-only");
+        let staged = scratch.0.join("out.pczt.tmp");
+        let dest = scratch.0.join("out.pczt");
+        std::fs::write(&staged, b"signed").unwrap();
+        std::fs::write(&dest, b"unsigned original").unwrap();
+        let mut permissions = dest.metadata().unwrap().permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&dest, permissions).unwrap();
+
+        replace_file(&staged, &dest).unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"signed");
+        assert!(!staged.exists());
+    }
+
+    #[test]
+    fn replace_file_works_when_destination_does_not_exist() {
+        let scratch = ScratchDir::new("replace-fresh");
+        let staged = scratch.0.join("out.pczt-signed.tmp");
+        let dest = scratch.0.join("out.pczt-signed");
+        std::fs::write(&staged, b"signed").unwrap();
+
+        replace_file(&staged, &dest).unwrap();
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"signed");
+        assert!(!staged.exists());
     }
 
     /// Smoke test for `redact_for_batch_signer`: an empty PCZT (no Orchard/Ironwood actions,


### PR DESCRIPTION
## Summary

Follow-up to the review on #217, targeting `zodl/ironwood-migration-testing`. Fixes the issues raised there:

- **`scan_for_ur` no longer aborts the whole scan on a `ur::Decoder::receive` error.** A frame of the expected UR type that the decoder rejects (stale QR from a previous run, the device looping an earlier message, a corrupted read that kept the type prefix) is now recorded in the status line and scanning continues — restoring the old `from-qr` loop's tolerance, instead of killing a multi-hundred-part session near the end.
- **Corrected the contradictory MJPEG comment** in `convert_buffer_to_image`: `scan_camera_format` does *not* request MJPEG (its own doc explains why that was abandoned); the MJPEG branch is defensive for other backends' negotiators.
- **Stale migration docs**: `migration advance`'s clap help now describes what it actually does (proves ready transactions; broadcast/rebuild remain unimplemented), and `advance.rs` no longer claims `migration status` uses a synthetic height — it uses the live tip, as `status.rs`'s own comment explains.
- **`migration commit --external` re-run handling**: fails fast with a clear message if `unsigned-pczts/` already exists (before doing any build work, and preventing stale `<id>.pczt` files from mixing into the suggested `*.pczt` glob), and cleans up the staged temp dir on any write/rename failure instead of stranding it next to the wallet.
- **Atomic signed-PCZT writes** in `apply_batch_signatures_and_write`: stage-and-rename instead of `fs::write` in place, so a crash mid-write can no longer destroy both the unsigned original and the signed result (the only output of a physical signing session). Matches the care `commit.rs` already takes.
- **Documented the Orchard-only signature-application assumption** (Ironwood actions' dummy sigs stay intact on the originals; real Ironwood spends would need their own path).
- Minor: `PCZT('s)` typo, preview status line now says "matching frames read" (the counter only counts expected-type frames), and the Cargo.toml version-req note no longer attributes the pins to the superseded `feat/pool-migration-sqlite` branch.

Not addressed (left as noted in review): the 0–9 interactive camera-picker limit (fine in practice), and confirming whether `Signer::apply_orchard_spend_auth_signature` verifies against `rk` (upstream `pczt` crate question).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --features regtest_support,pczt-qr --all-targets -- -D warnings` clean
- [x] `cargo test --features regtest_support,pczt-qr` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
