### PR TITLE
Restrict GITHUB_TOKEN to read-only in speed.yml and cache-bump.yml

### DIFF
--- a/.github/workflows/cache-bump.yml
+++ b/.github/workflows/cache-bump.yml
@@ -5,6 +5,12 @@ on:
     # Daily at 2:42pm UTC
     - cron: '42 14 * * *'
 
+# Restrict the default GITHUB_TOKEN to read-only. This workflow never checks out
+# the repository and only touches the Actions cache, which authenticates with the
+# runtime token rather than GITHUB_TOKEN, so it needs nothing beyond this.
+permissions:
+  contents: read
+
 jobs:
   wallet-sync:
     name: Refresh cached wallet state from ${{ matrix.days }} days ago

--- a/.github/workflows/speed.yml
+++ b/.github/workflows/speed.yml
@@ -12,6 +12,12 @@ on:
         default: false
         type: boolean
 
+# Restrict the default GITHUB_TOKEN to read-only; jobs that need more opt in below.
+# Nothing here does: checkout only reads, the artifact and cache actions authenticate
+# with the runtime token rather than GITHUB_TOKEN, and bencher uses its own API token.
+permissions:
+  contents: read
+
 jobs:
   build-binary:
     name: Build binary for testing


### PR DESCRIPTION
Closes #221. Clears the three remaining open CodeQL alerts, all `actions/missing-workflow-permissions`. Two files, six added lines plus comments.

| Alert | Workflow | Job |
|---|---|---|
| [#22](https://github.com/zcash/zcash-devtool/security/code-scanning/22) | `speed.yml:17` | `build-binary` |
| [#6](https://github.com/zcash/zcash-devtool/security/code-scanning/6) | `speed.yml:32` | `wallet-sync` |
| [#2](https://github.com/zcash/zcash-devtool/security/code-scanning/2) | `cache-bump.yml:10` | `wallet-sync` |

Neither workflow declared a `permissions:` block, so `GITHUB_TOKEN` fell back to the repository-wide default — which may be read/write. (I couldn't confirm which: reading `/actions/permissions/workflow` returns 403 for my token. If the repo default is already restricted the practical exposure is nil, but the explicit declaration is still the right fix and is what closes the alerts.)

`ci.yml` was already hardened this way — top-level `permissions: contents: read`, with the Clippy job opting into `checks: write` — and its four equivalent alerts (#1, #3, #5, #7) are all fixed. This applies the identical pattern to the two workflows that were missed.

### Why `contents: read` is sufficient

No job in either workflow needs more:

- **`speed.yml` / `build-binary`** — checks out (read-only, already with `persist-credentials: false`) and uploads an artifact. `actions/upload-artifact` authenticates with `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`.
- **`speed.yml` / `wallet-sync`** — downloads a *same-run* artifact and reads/writes the Actions cache; both are runtime-token paths. (Only cross-run artifact downloads, which pass `run-id` + `github-token`, would need `actions: read`.) Bencher authenticates with its own `BENCHER_API_TOKEN` secret.
- **`cache-bump.yml` / `wallet-sync`** — never checks out the repository at all; it only restores from the Actions cache.

`cache-bump.yml` could arguably take `permissions: {}` since it touches no repo contents whatsoever. I used `contents: read` for consistency with the other two workflows, and so that adding a checkout later doesn't fail confusingly.

### Verification

Both files parse, the new blocks sit at workflow level (not nested into a job), and every job is preserved — confirmed against `ci.yml` as the reference:

```
speed.yml      -> top-level permissions: {"contents"=>"read"} | jobs: ["build-binary", "wallet-sync"]
cache-bump.yml -> top-level permissions: {"contents"=>"read"} | jobs: ["wallet-sync"]
ci.yml         -> top-level permissions: {"contents"=>"read"} | jobs: [...]
   job clippy permissions: {"contents"=>"read", "checks"=>"write"}
```

### One caveat

**This PR's CI run does not exercise either workflow.** `speed.yml` is `schedule` + `workflow_dispatch` and `cache-bump.yml` is `schedule`-only, so neither triggers on a pull request — a green check here says nothing about them. The change is declarative config that I've verified parses and mirrors a pattern already working in `ci.yml`, so the risk is low, but the real confirmation is the next scheduled run (cache-bump 14:42 UTC, speed 10:37 UTC). I did not dispatch `speed.yml` manually to test, since it performs a real wallet sync against a live server; say the word if you'd like me to, with `store: false` so it won't write the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)