### PR TITLE
Take six Dependabot dependency bumps, with tests pinning the formats they touch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,18 +755,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
-name = "bitcoin-private"
-version = "0.1.0"
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.12.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+checksum = "a67800fcf7f3ca52f7796d4466948a424326b225950c79d1e76d0458760bb25d"
 dependencies = [
- "bitcoin-private",
+ "bitcoin-consensus-encoding",
+ "bitcoin-internals",
 ]
 
 [[package]]
@@ -3973,23 +3983,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicbor"
-version = "0.19.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
-dependencies = [
- "minicbor-derive",
-]
-
-[[package]]
-name = "minicbor-derive"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "c12b4033ffaa92fbf9df03df38d19324f52bad130dd223f811734a8006dd2d69"
 
 [[package]]
 name = "minimal-lexical"
@@ -5407,6 +5403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5438,11 +5440,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -8572,14 +8574,13 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ur"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010f24a953db5d22d0010969ca3bbf40b3857b89f47c0f7be0da4c2d7ded0760"
+checksum = "28bccbac381852c37efd0217ce8c96742e5cf22f6dbb2a4f0f51418c7f3ab980"
 dependencies = [
  "bitcoin_hashes",
  "crc",
  "minicbor",
- "phf 0.11.3",
  "rand_xoshiro",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,28 +31,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "age"
-version = "0.11.5"
+name = "aes-gcm"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047a482d1843edf1ce76ada63183698144030fe1191bd5ddba6e41e164e0bc43"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "age"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26"
 dependencies = [
  "age-core",
- "base64 0.21.7",
- "bech32 0.9.1",
+ "base64",
+ "bech32",
  "chacha20poly1305",
+ "cipher",
  "cookie-factory",
+ "hkdf",
  "hmac 0.12.1",
+ "hpke",
  "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
- "nom 7.1.3",
+ "ml-kem",
+ "nom 8.0.0",
+ "p256",
  "pin-project",
  "rand 0.8.7",
  "rust-embed",
  "scrypt",
  "sha2 0.10.9",
+ "sha3",
  "subtle",
- "which 4.4.2",
+ "which 8.0.5",
  "wsl",
  "x25519-dalek",
  "zeroize",
@@ -60,16 +80,18 @@ dependencies = [
 
 [[package]]
 name = "age-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
+checksum = "01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656"
 dependencies = [
- "base64 0.21.7",
+ "base64",
+ "bech32",
  "chacha20poly1305",
  "cookie-factory",
  "hkdf",
+ "hpke",
  "io_tee",
- "nom 7.1.3",
+ "nom 8.0.0",
  "rand 0.8.7",
  "secrecy 0.10.3",
  "sha2 0.10.9",
@@ -587,12 +609,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -611,12 +627,6 @@ checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bech32"
@@ -1578,6 +1588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2119,6 +2130,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -2418,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "fluent"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+checksum = "8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477"
 dependencies = [
  "fluent-bundle",
  "unic-langid",
@@ -2428,16 +2440,16 @@ dependencies = [
 
 [[package]]
 name = "fluent-bundle"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
 dependencies = [
  "fluent-langneg",
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 1.1.0",
- "self_cell 0.10.3",
+ "rustc-hash 2.1.3",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -2453,11 +2465,12 @@ dependencies = [
 
 [[package]]
 name = "fluent-syntax"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
- "thiserror 1.0.69",
+ "memchr",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2779,6 +2792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,6 +3053,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
 
 [[package]]
+name = "hpke"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest 0.10.7",
+ "generic-array",
+ "hkdf",
+ "hmac 0.12.1",
+ "p256",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,9 +3213,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+checksum = "a217bbb075dcaefb292efa78897fc0678245ca67f265d12c351e42268fcb0305"
 dependencies = [
  "arc-swap",
  "fluent",
@@ -3190,16 +3233,16 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed-fl"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+checksum = "602e6bd30c3db2749e13e38b363a3d98d9d41de1d8de7a79c31bb69e45b47cda"
 dependencies = [
  "find-crate",
  "fluent",
  "fluent-syntax",
  "i18n-config",
  "i18n-embed",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
@@ -3609,6 +3652,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "known-folders"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3964,6 +4017,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3",
 ]
 
 [[package]]
@@ -4938,6 +5003,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5035,25 +5112,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -6201,15 +6278,6 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.3.0",
-]
-
-[[package]]
-name = "self_cell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
@@ -6307,7 +6375,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bs58",
  "chrono",
  "hex",
@@ -6811,7 +6879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
@@ -7171,7 +7239,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "flate2",
  "h2",
@@ -9345,7 +9413,7 @@ version = "0.1.0"
 dependencies = [
  "age",
  "anyhow",
- "bech32 0.11.1",
+ "bech32",
  "bellman",
  "bip0039",
  "bip32",
@@ -9423,7 +9491,7 @@ name = "zcash_address"
 version = "0.13.0"
 source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "bs58",
  "corez",
  "f4jumble",
@@ -9439,8 +9507,8 @@ dependencies = [
  "ambassador",
  "arti-client",
  "assert_matches",
- "base64 0.22.1",
- "bech32 0.11.1",
+ "base64",
+ "bech32",
  "bip32",
  "bls12_381",
  "bs58",
@@ -9570,7 +9638,7 @@ name = "zcash_keys"
 version = "0.16.1"
 source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "bip32",
  "blake2b_simd",
  "bls12_381",
@@ -9809,7 +9877,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64bf5186a8916f7a48f2a98ef599bf9c099e2458b36b819e393db1c0e768c4b"
 dependencies = [
- "bech32 0.11.1",
+ "bech32",
  "blake2b_simd",
  "memuse",
  "subtle",
@@ -9821,7 +9889,7 @@ name = "zip321"
 version = "0.9.0-rc.1"
 source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "nom 7.1.3",
  "percent-encoding",
  "zcash_address",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -240,7 +240,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1970,7 +1970,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2225,7 +2225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3614,7 +3614,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4199,7 +4199,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5941,7 +5941,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6551,7 +6551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6767,7 +6767,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6780,7 +6780,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8891,7 +8891,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -240,7 +240,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1970,7 +1970,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2225,7 +2225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2859,7 +2859,7 @@ dependencies = [
  "rand 0.8.7",
  "sinsemilla",
  "subtle",
- "uint",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -3614,7 +3614,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4199,7 +4199,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5941,7 +5941,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6551,7 +6551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6767,7 +6767,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6780,7 +6780,7 @@ dependencies = [
  "parking_lot",
  "rustix 1.1.4",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8391,6 +8391,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8891,7 +8903,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9387,7 +9399,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-logger",
- "uint",
+ "uint 0.10.0",
  "ur",
  "uuid",
  "zcash_address",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if 1.0.4",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "zeroize",
 ]
 
@@ -690,13 +690,16 @@ dependencies = [
 
 [[package]]
 name = "bip0039"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568b6890865156d9043af490d4c4081c385dd68ea10acd6ca15733d511e6b51c"
+checksum = "2da3803045ec5ba2ee8f65eb36b29115ec8a05fe519a7ae023c84770bd5f676b"
 dependencies = [
+ "anyhow",
  "hmac 0.12.1",
  "pbkdf2",
- "rand 0.8.7",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "rand 0.10.2",
  "sha2 0.10.9",
  "unicode-normalization",
  "zeroize",
@@ -1077,7 +1080,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if 1.0.4",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1087,7 +1101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1430,6 +1444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,7 +1660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -2788,6 +2811,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3658,7 +3682,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -4830,6 +4854,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4993,7 +5027,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5005,7 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5362,6 +5396,17 @@ checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6420,7 +6465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -6431,7 +6476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -6442,7 +6487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.11.0-pre.9",
 ]
 
@@ -6862,7 +6907,7 @@ dependencies = [
  "fnv",
  "nom 7.1.3",
  "phf 0.11.3",
- "phf_codegen",
+ "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -9670,7 +9715,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "cipher",
  "rand_core 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("nu
 
 [dependencies]
 anyhow = "1"
-bip0039 = { version = "0.12", features = ["std", "all-languages"] }
+bip0039 = { version = "0.14", features = ["std", "all-languages"] }
 bip32 = { version = "=0.6.0-pre.1", default-features = false, features = ["secp256k1-ffi"] }
 futures-util = "0.3"
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ clap = { version = "4.5", features = ["derive", "string", "unstable-styles"] }
 rand = { version = "0.8", default-features = false }
 
 # Seed encryption
-age = { version = "0.11", features = ["armor", "plugin"] }
+age = { version = "0.12", features = ["armor", "plugin"] }
 chrono = "0.4"
 rpassword = "7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ group = "0.13"
 lazy_static = "1"
 serde_json = "1"
 sha2 = "0.10"
-uint = "0.9"
+uint = "0.10"
 zcash_encoding = "0.4"
 zcash_note_encryption = "0.4.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,11 +110,11 @@ zcash_note_encryption = "0.4.1"
 
 # PCZT QR codes
 image = { version = "0.25", optional = true }
-minicbor = { version = "0.19", optional = true }
+minicbor = { version = "2.2", optional = true }
 nokhwa = { version = "0.10", optional = true, features = ["input-native"] }
 qrcode = { version = "0.14", optional = true, default-features = false }
 rqrr = { version = "0.10.1", optional = true }
-ur = { version = "0.4", optional = true }
+ur = { version = "0.5", optional = true }
 
 # Tree exploration
 incrementalmerkletree = "0.8"

--- a/src/commands/keystone.rs
+++ b/src/commands/keystone.rs
@@ -132,7 +132,7 @@ impl<C> minicbor::Encode<C> for ZcashAccounts {
         e.int(Int::from(ACCOUNTS))?
             .array(self.accounts.len() as u64)?;
         for account in &self.accounts {
-            e.tag(Tag::Unassigned(ZCASH_UNIFIED_FULL_VIEWING_KEY))?;
+            e.tag(Tag::new(ZCASH_UNIFIED_FULL_VIEWING_KEY))?;
             ZcashUnifiedFullViewingKey::encode(account, e, _ctx)?;
         }
 

--- a/src/commands/pczt/qr.rs
+++ b/src/commands/pczt/qr.rs
@@ -1310,3 +1310,97 @@ mod tests {
         );
     }
 }
+
+/// The CBOR and UR encodings below are a wire format shared with Keystone
+/// hardware wallets. A dependency bump that still compiles can silently change
+/// the bytes on the wire and break signing against real devices, so these
+/// vectors pin the encoding rather than exercising the codec against itself.
+///
+/// The expected values were captured from this same code under the previous
+/// `minicbor` 0.19 / `ur` 0.4 pair and are unchanged under `minicbor` 2 / `ur` 0.5.
+#[cfg(test)]
+mod wire_format_tests {
+    use super::*;
+
+    /// Deterministic stand-in for a serialized PCZT: long enough that the UR
+    /// encoder must fragment it, so the fountain parts are covered too.
+    fn sample_payload() -> Vec<u8> {
+        (0u16..220).map(|i| (i % 251) as u8).collect()
+    }
+
+    const EXPECTED_PCZT_CBOR: &str = "a10158dc000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadb";
+
+    const EXPECTED_BATCH_CBOR: &str = "a20158dc000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadb0250aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    /// Four consecutive parts: the three that carry the payload, plus one
+    /// fountain-combined part, which exercises the XOR path as well.
+    const EXPECTED_UR_PARTS: &[&str] = &[
+        "ur:zcash-pczt/1-3/lpadaxcsvtcydyzmmnwkhdgroyadhduoaeadaoaxaaahamatayasbkbdbnbtbabsbebybgbwbbbzcmchcscfcycwcecackctcxclcpcndkdadsdidedtdrdndwdpdmdldyeheyeoeeecenemetesftfrfnfsfmfhfzfpfwfxfyfefgahsfyavl",
+        "ur:zcash-pczt/2-3/lpaoaxcsvtcydyzmmnwkhdgrflfdgagegrgsgtglgwgdgygmgughgohfhghdhkhthphhhlhyhehnhsidiaieihiyioisinimjejzjnjtjljojsjpjkjykpkoktkskkknkgkekikblblalylflslrlplnltloldlelulklgmnmymhmefhsprehl",
+        "ur:zcash-pczt/3-3/lpaxaxcsvtcydyzmmnwkhdgrmomumwmdmtmsmknlnyndnsntnnnenboyoeotoxonolospdptpkpypspmplpepfpaprqdqzrerprlrorhrdrkrfryrnrsrtsesasrssskswstspsosgsbsfsntotktitttdtetytltbtstptatnuyaesrbnzesb",
+        "ur:zcash-pczt/4-3/lpaaaxcsvtcydyzmmnwkhdgrvagabymtgrgtgwgtgrgohggohphlhehlhpgohggogrgtgwgtgrkpktkpkgkilbkikgkpktkpgrgtgwgtgrgohggohphlhehlhpgohggogrgtgwgtgrrerlrerkryrsryrkrerlresbsntksnsbtltsbtiaryga",
+    ];
+
+    #[test]
+    fn zcash_pczt_cbor_encoding_is_unchanged() {
+        let mut packet = vec![];
+        minicbor::encode(
+            &ZcashPczt {
+                data: sample_payload(),
+            },
+            &mut packet,
+        )
+        .expect("encoding succeeds");
+        assert_eq!(hex::encode(&packet), EXPECTED_PCZT_CBOR);
+    }
+
+    #[test]
+    fn zcash_sign_batch_cbor_encoding_is_unchanged() {
+        let mut packet = vec![];
+        minicbor::encode(
+            &ZcashSignBatch {
+                data: sample_payload(),
+                request_id: vec![0xAA; 16],
+            },
+            &mut packet,
+        )
+        .expect("encoding succeeds");
+        assert_eq!(hex::encode(&packet), EXPECTED_BATCH_CBOR);
+    }
+
+    #[test]
+    fn ur_fragmentation_is_unchanged() {
+        let mut packet = vec![];
+        minicbor::encode(
+            &ZcashPczt {
+                data: sample_payload(),
+            },
+            &mut packet,
+        )
+        .expect("encoding succeeds");
+
+        let mut encoder = ur::Encoder::new(&packet, 100, ZCASH_PCZT).expect("UR encoder builds");
+        let parts: Vec<String> = (0..EXPECTED_UR_PARTS.len())
+            .map(|_| encoder.next_part().expect("part encodes"))
+            .collect();
+
+        assert_eq!(parts, EXPECTED_UR_PARTS);
+    }
+
+    /// The decode side must still read what the encode side writes.
+    #[test]
+    fn zcash_pczt_cbor_round_trips() {
+        let payload = sample_payload();
+        let mut packet = vec![];
+        minicbor::encode(
+            &ZcashPczt {
+                data: payload.clone(),
+            },
+            &mut packet,
+        )
+        .expect("encoding succeeds");
+
+        let decoded = minicbor::decode::<'_, ZcashPczt>(&packet).expect("decoding succeeds");
+        assert_eq!(decoded.data, payload);
+    }
+}

--- a/src/commands/wallet/fan_out.rs
+++ b/src/commands/wallet/fan_out.rs
@@ -71,7 +71,7 @@ impl PaymentContext for FanOutRound {
         self.account_id
     }
 
-    fn age_identities(&self) -> anyhow::Result<Vec<Box<dyn Identity>>> {
+    fn age_identities(&self) -> anyhow::Result<Vec<Box<dyn Identity + Send + Sync>>> {
         let identities = age::IdentityFile::from_file(self.identity.clone())?.into_identities()?;
         Ok(identities)
     }

--- a/src/commands/wallet/pay.rs
+++ b/src/commands/wallet/pay.rs
@@ -52,7 +52,7 @@ impl PaymentContext for Command {
         self.account_id
     }
 
-    fn age_identities(&self) -> anyhow::Result<Vec<Box<dyn Identity>>> {
+    fn age_identities(&self) -> anyhow::Result<Vec<Box<dyn Identity + Send + Sync>>> {
         let identities = age::IdentityFile::from_file(self.identity.clone())?.into_identities()?;
         Ok(identities)
     }

--- a/src/commands/wallet/send.rs
+++ b/src/commands/wallet/send.rs
@@ -91,7 +91,7 @@ pub(crate) struct Command {
 
 pub(crate) trait PaymentContext {
     fn spending_account(&self) -> Option<Uuid>;
-    fn age_identities(&self) -> anyhow::Result<Vec<Box<dyn Identity>>>;
+    fn age_identities(&self) -> anyhow::Result<Vec<Box<dyn Identity + Send + Sync>>>;
     fn connection_args(&self) -> &ConnectionArgs;
     fn target_note_count(&self) -> usize;
     fn min_split_output_value(&self) -> u64;
@@ -107,7 +107,7 @@ impl PaymentContext for Command {
         self.account_id
     }
 
-    fn age_identities(&self) -> anyhow::Result<Vec<Box<dyn Identity>>> {
+    fn age_identities(&self) -> anyhow::Result<Vec<Box<dyn Identity + Send + Sync>>> {
         let identities = age::IdentityFile::from_file(self.identity.clone())?.into_identities()?;
         Ok(identities)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -413,6 +413,14 @@ jRW+ziYGUZgR+/lTdkPqVkIYF3HD73VeQcAN6Q==
         TEST_PHRASE.split_whitespace().collect::<Vec<_>>().join(" ")
     }
 
+    /// BIP-39 seed for `TEST_PHRASE` with an empty passphrase, computed
+    /// independently of this crate's dependencies as
+    /// `PBKDF2-HMAC-SHA512(phrase, "mnemonic", 2048, 64)`. Hard-coded rather
+    /// than derived through `bip0039` so that a change in how that crate
+    /// derives seeds is caught here instead of cancelling itself out.
+    const EXPECTED_SEED_HEX: &str = "9070562a53e5306c09ff0b3f30924658001139798a7a07c42b43c07751fdb43a\
+                                     6ac32f5a11f7015025b4558a115ecbee7a6aa62824f698f844d49e97550d20db";
+
     fn identity() -> age::x25519::Identity {
         TEST_IDENTITY.parse().expect("test identity parses")
     }
@@ -443,11 +451,10 @@ jRW+ziYGUZgR+/lTdkPqVkIYF3HD73VeQcAN6Q==
         )
         .expect("seed derives from the age 0.11 ciphertext");
 
-        let expected = <Mnemonic<English>>::from_phrase(phrase())
-            .expect("test phrase is a valid mnemonic")
-            .to_seed("");
-
-        assert_eq!(seed.expose_secret().as_slice(), &expected[..]);
+        assert_eq!(
+            hex::encode(seed.expose_secret()),
+            EXPECTED_SEED_HEX.split_whitespace().collect::<String>(),
+        );
     }
 
     /// Guard the other direction: what we write today must read back.

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,3 +376,99 @@ mod tests {
         fs::remove_dir_all(&dir).unwrap();
     }
 }
+
+/// Seed encryption is the one place where a dependency upgrade can silently
+/// lock users out of an existing wallet, so these tests pin the on-disk
+/// format rather than just exercising the current API against itself.
+#[cfg(test)]
+mod age_compat_tests {
+    use super::*;
+
+    /// Test-only key. It protects nothing but the fixture below.
+    const TEST_IDENTITY: &str =
+        "AGE-SECRET-KEY-1T2376TDD3NNRFPKVU9VAK8E8HP6P5HW6KL0WTYZAFKAFMQX8SKMSHNQELQ";
+
+    /// The same throwaway mnemonic already published in `.github/workflows/speed.yml`.
+    const TEST_PHRASE: &str = "wine gesture someone salmon deposit fit depart marble seed chat \
+                               sick wood illegal trim coast scheme sword enter shiver disagree \
+                               marble short blind carry";
+
+    /// Produced by `encrypt_mnemonic` while this crate was still on age 0.11,
+    /// standing in for a `keys.toml` written by an older build of the tool.
+    const AGE_0_11_CIPHERTEXT: &str = "\
+-----BEGIN AGE ENCRYPTED FILE-----
+YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArei9Ua29rWlg3aFdqSTcx
+YzBKbExoWFUxYUhwaFl5Y0xSVzJlaTV2U3hRCjBWMkhRdDVhWjJsM0Q3dVhCZnNE
+ZU9VcVV6bW9TTE1DdVNVbEluMi9uL2sKLT4gMlNFc30tZ3JlYXNlIEVgClVKYUhy
+Rm9nRjltclg1Vks3SlVyUG5Vc2RWdGNaYmxOS0RtVjlZam0KLS0tIFkrR0dBbjdW
+STErSXlNZWhFcnNMaGYxZjN6bTJQd0xROUJKMlZSOWhkYTgK6aEEcSwPN4JRdAhP
+2m8mgN+4f/4hIRMsBuiMm1GYQyYJzLQ4z2pK+QMzJVsUYcG7QOGRaDeOr0F9n45k
+j3GXXXAowjUwmgG6J34Z2PR904VFX35hdgxoaZZiijrJzvZ2N+6NI9r6FdNq5HWs
+YbqDyi3goiJhF8/i5yYqiwrQXvZ/TzK026b7iVHT45qGGzDwYIjy3JDIz8NRXZmB
+jRW+ziYGUZgR+/lTdkPqVkIYF3HD73VeQcAN6Q==
+-----END AGE ENCRYPTED FILE-----
+";
+
+    fn phrase() -> String {
+        TEST_PHRASE.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    fn identity() -> age::x25519::Identity {
+        TEST_IDENTITY.parse().expect("test identity parses")
+    }
+
+    /// A wallet whose seed was encrypted by an age 0.11 build must still open.
+    #[test]
+    fn ciphertext_written_by_age_0_11_still_decrypts() {
+        let id = identity();
+        let recovered = decrypt_mnemonic(
+            std::iter::once(&id as &dyn age::Identity),
+            AGE_0_11_CIPHERTEXT,
+        )
+        .expect("age 0.11 ciphertext decrypts under the current age release");
+
+        assert_eq!(
+            std::str::from_utf8(recovered.expose_secret()).unwrap(),
+            phrase(),
+        );
+    }
+
+    /// ...and must derive the same seed, not merely the same mnemonic bytes.
+    #[test]
+    fn seed_from_age_0_11_ciphertext_is_unchanged() {
+        let id = identity();
+        let seed = decrypt_seed(
+            std::iter::once(&id as &dyn age::Identity),
+            AGE_0_11_CIPHERTEXT,
+        )
+        .expect("seed derives from the age 0.11 ciphertext");
+
+        let expected = <Mnemonic<English>>::from_phrase(phrase())
+            .expect("test phrase is a valid mnemonic")
+            .to_seed("");
+
+        assert_eq!(seed.expose_secret().as_slice(), &expected[..]);
+    }
+
+    /// Guard the other direction: what we write today must read back.
+    #[test]
+    fn encrypt_decrypt_round_trips() {
+        let id = identity();
+        let recipient = id.to_public();
+        let mnemonic = <Mnemonic<English>>::from_phrase(phrase()).unwrap();
+
+        let ciphertext = encrypt_mnemonic(
+            std::iter::once(&recipient as &dyn age::Recipient),
+            &mnemonic,
+        )
+        .expect("encryption succeeds");
+
+        let recovered = decrypt_mnemonic(std::iter::once(&id as &dyn age::Identity), &ciphertext)
+            .expect("round trip decrypts");
+
+        assert_eq!(
+            std::str::from_utf8(recovered.expose_secret()).unwrap(),
+            phrase(),
+        );
+    }
+}


### PR DESCRIPTION
Closes #223. Clears six of the eight open Dependabot version-bump PRs. None had a security advisory behind them — that work landed in #220.

> **Rebased onto #213.** That Dependabot PR (`clap` → 4.6.4) was merged to `main` while this branch was in flight, which conflicted here. Resolved by merging `main` in and keeping 4.6.5, which is strictly newer; the `clap` row below is now a small increment on top of what already landed rather than the whole bump.

| Dependabot PR | Bump | Source changes |
|---|---|---|
| #213 *(already merged)* | `clap` 4.6.4 → **4.6.5** | none (lockfile only) |
| #187 | `uint` 0.9.5 → **0.10.0** | none |
| #214 | `age` 0.11.5 → **0.12.1** | 3 signatures widened |
| #215 | `ur` 0.4.1 → **0.5.2** | none |
| #192 | `minicbor` 0.19.1 → **2.3.0** | one call |
| #194 | `bip0039` 0.12.0 → **0.14.0** | none |

Three of these touch formats where a bump that merely compiles can still be wrong, so each is backed by a test pinning the format rather than checking the new version against itself. **7 new tests; suite goes 21 → 28.**

### `age` 0.12 — seed encryption

0.12 adds `Send + Sync` to the identities from `IdentityFile::into_identities()`, so `PaymentContext::age_identities` and its three impls widen to `Vec<Box<dyn Identity + Send + Sync>>`. Widening beats stripping the bounds per call site: `send::create_transaction` holds identities across an `.await`, so the extra bounds help that future stay `Send`. The one consumer passes them on as `&dyn Identity` via `as _`, which still coerces — dropping auto traits from a trait object is allowed.

**This is the one place an upgrade could lock a user out of an existing wallet.** I generated a ciphertext through `encrypt_mnemonic` while the crate was still on age 0.11, then checked it against 0.12: it decrypts, and derives the identical seed. That fixture is now a test, so a future bump can't quietly break old `keys.toml` files. Verified non-vacuous — flipping one character of the fixture fails both fixture tests while the round-trip test still passes.

### `ur` 0.5 + `minicbor` 2 — Keystone wire format

**These two cannot be taken separately**, which is why they'd both been sitting: `ur` 0.5 requires `minicbor ^2.0`, so bumping `ur` alone puts two `minicbor` majors in the graph and the hand-written `Encode`/`Decode` impls stop satisfying `minicbor::encode::Write`.

One source change: `Tag::Unassigned(n)` → `Tag::new(n)`. minicbor 0.19's `Tag` was an enum whose `Unassigned(n)` arm lowered to the raw tag `n`; minicbor 2's is a newtype over `u64` with the same lowering, so tag 49203 is emitted identically — I checked both crates' sources rather than assuming.

These types are shared with Keystone hardware wallets, where changed bytes would silently break signing against real devices. I captured the encodings under the old `minicbor` 0.19 / `ur` 0.4 pair and compared: the `ZcashPczt` and `ZcashSignBatch` CBOR and the UR fragments are **byte-identical**, including a fountain-combined part, which covers the XOR path. Those vectors are now tests.

### `bip0039` 0.14 — seed derivation

No source changes. But the age test above couldn't have caught a derivation change: it derived its own expected value through `bip0039`, so both sides of the assertion would have moved together. Replaced with a vector computed independently of this crate's dependencies as `PBKDF2-HMAC-SHA512(phrase, "mnemonic", 2048, 64)` — the BIP-39 definition — so the test now pins the derivation itself.

### `uint` 0.10

The only breaking change is `to_big_endian`/`to_little_endian` moving from `(&self, &mut [u8])` to `(&self) -> [u8; N]`; neither is called here. The two constructors `inspect::block` does use for compact-target and PoW-hash comparisons have byte-for-byte identical bodies in 0.9.5 and 0.10.0. `halo2_gadgets` still needs `uint` 0.9, so both majors stay in the lockfile — harmless, since `construct_uint!` generates a local type per crate.

### The two I did not take — both verified blocked, not assumed

- **#190 `group` 0.13 → 0.14.** I tried it. With two `group` majors in the graph, `jubjub` (still on 0.13) no longer supplies `GroupEncoding::from_bytes` to our code: `inspect/address.rs` and `inspect/transaction.rs` fail with `no associated function named from_bytes found for SubgroupPoint`/`ExtendedPoint`. 18 crates in the zcash stack pin `group` 0.13; this needs the ecosystem to move first.
- **#216 `rand` 0.8 → 0.9.** Also tried. `rand` 0.9's `OsRng` doesn't implement the `rand_core` 0.6 `RngCore`/`CryptoRng` that the zcash crates require, so every `propose_transfer` / `create_pczt_from_proposal` / `build_for_pczt` call site fails. The lockfile already carries both majors — zcash on 0.8, the Tor stack on 0.9 — and they can't be unified from here.

Both remain open and are noted in #223.

### Verification

- `cargo build` (default) and `--features tui,pczt-qr,qr,regtest_support` — clean
- `cargo test --features tui,pczt-qr,qr,regtest_support` — **28 passed, 0 failed**
- `cargo clippy --all-targets -- -D warnings`, default and full feature set — zero errors
- `cargo fmt --all -- --check` — clean

### One caveat

The new tests pin encodings and derivations, which is the part a dependency bump is most likely to break silently. They are **not** end-to-end: I have not driven a real Keystone device, a camera QR scan, or a real wallet unlock. `pczt-qr` and `tui` aren't built by any CI job either. If anyone has a Keystone to hand, a `pczt to-qr` → sign → `from-qr` round trip would be the last mile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
