### PR TITLE
Pin the legacy zcash-accounts wire format and run pczt-qr tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,26 @@ jobs:
       - name: Clippy with regtest_support
         run: cargo clippy --all-targets --features regtest_support -- -D warnings
 
+  # The pczt-qr feature carries the CBOR/UR wire format shared with Keystone
+  # hardware wallets, and its fixed-vector tests are what protect that
+  # interoperability across dependency bumps -- so they must run in CI, not
+  # just compile. nokhwa's camera backends are platform-specific native code,
+  # hence the OS matrix.
+  pczt-qr:
+    name: Build, test, and lint with pczt-qr on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build with pczt-qr
+        run: cargo build --features pczt-qr
+      - name: Test with pczt-qr
+        run: cargo test --features pczt-qr
+      - name: Clippy with pczt-qr
+        run: cargo clippy --all-targets --features pczt-qr -- -D warnings
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/src/commands/keystone.rs
+++ b/src/commands/keystone.rs
@@ -158,3 +158,101 @@ impl<C> minicbor::Encode<C> for ZcashUnifiedFullViewingKey {
         Ok(())
     }
 }
+
+/// The `zcash-accounts` CBOR and UR encodings below are the wire format the
+/// `keystone enroll` command shares with Keystone hardware wallets: a changed
+/// byte here means a device no longer recognises an enrollment QR, so these
+/// vectors pin the encoding rather than exercising the codec against itself.
+///
+/// The expected values were captured from this same encoder as it existed
+/// before the `minicbor` 0.19 -> 2 / `ur` 0.4 -> 0.5 migration (in particular
+/// `Tag::Unassigned(49203)` -> `Tag::new(49203)`), by compiling it against the
+/// old crate pair. They must never change.
+#[cfg(test)]
+mod wire_format_tests {
+    use super::*;
+
+    /// Deterministic stand-in for an encoded UFVK: same `uview1` HRP and
+    /// typical length (280 chars) as a real mainnet UFVK, built from the
+    /// bech32 alphabet. The encoder treats it as an opaque string.
+    fn sample_ufvk() -> String {
+        const ALPHABET: &[u8] = b"qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+        let tail: String = (0..274)
+            .map(|i| ALPHABET[(i * 7) % ALPHABET.len()] as char)
+            .collect();
+        format!("uview1{tail}")
+    }
+
+    /// Two accounts so both map shapes are pinned: one with the optional
+    /// `name` entry (a 3-entry map) and one without (a 2-entry map). The
+    /// multi-byte account index pins the u32 encoding beyond the one-byte
+    /// small-int range.
+    fn sample_accounts() -> ZcashAccounts {
+        ZcashAccounts {
+            seed_fingerprint: core::array::from_fn(|i| i as u8),
+            accounts: vec![
+                ZcashUnifiedFullViewingKey {
+                    ufvk: sample_ufvk(),
+                    index: 0x0102_0304,
+                    name: Some("Keystone enrollment fixture".into()),
+                },
+                ZcashUnifiedFullViewingKey {
+                    ufvk: sample_ufvk(),
+                    index: 0,
+                    name: None,
+                },
+            ],
+        }
+    }
+
+    const EXPECTED_ACCOUNTS_CBOR: &str = "a2015820000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f0282d9c033a3017901187576696577317138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a667368021a0102030403781b4b657973746f6e6520656e726f6c6c6d656e742066697874757265d9c033a2017901187576696577317138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673683739766e367067306b6179746a657138773475723233636c7864356d7a6673680200";
+
+    /// Eight consecutive parts: the seven that carry the payload, plus one
+    /// fountain-combined part, which exercises the XOR path as well.
+    const EXPECTED_UR_PARTS: &[&str] = &[
+        "ur:zcash-accounts/1-7/lpadatcfaolkcyhkzsvegshdhyoeadhdcxaeadaoaxaaahamatayasbkbdbnbtbabsbebybgbwbbbzcmchcscfcycwcecackctaolftarteootadkkadcskpkoinihktehjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzeotsluhd",
+        "ur:zcash-accounts/2-7/lpaoatcfaolkcyhkzsvegshdhyksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoemtkhkfm",
+        "ur:zcash-accounts/3-7/lpaxatcfaolkcyhkzsvegshdhyiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpesnnjtfs",
+        "ur:zcash-accounts/4-7/lpaaatcfaolkcyhkzsvegshdhyeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisaocyadaoaxaaaxkscwgrihkkjkjyjljtihcxihjtjpjljzjzjnihjtjycxiyinksjykpjpihtarteooeadkkadcskpkoinihktehurtbwzey",
+        "ur:zcash-accounts/5-7/lpahatcfaolkcyhkzsvegshdhyjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyvepylycx",
+        "ur:zcash-accounts/6-7/lpamatcfaolkcyhkzsvegshdhyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehsosknwflr",
+        "ur:zcash-accounts/7-7/lpatatcfaolkcyhkzsvegshdhykkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisemeskojtenjoiodyjehskkjyimihjsetkteekpjpeyeoiajzksieecjnkniyjkisaoaeaeaeaeaeaeaekoetimkp",
+        "ur:zcash-accounts/8-7/lpayatcfaolkcyhkzsvegshdhygdcybsahbdcyahcshygrhtgucfhhfpadbkbwhkathkhybagugtgrgrcfaobybtaogdcybsahbdcyahcshygrhtgudwlbenjnfhiofsgwdtjybghyghhtgogwbeahcackbefgaeahckcwhyadaagrfzfxhtbefebkvwotbtmdeofgfxamdkeniheeihdkjpiekski",
+    ];
+
+    #[test]
+    fn zcash_accounts_cbor_encoding_is_unchanged() {
+        let mut packet = vec![];
+        minicbor::encode(sample_accounts(), &mut packet).expect("encoding succeeds");
+        assert_eq!(hex::encode(&packet), EXPECTED_ACCOUNTS_CBOR);
+    }
+
+    /// The registry tag is what lets Keystone firmware recognise each UFVK
+    /// entry; `Tag::new(49203)` must keep lowering to the same bytes that
+    /// `Tag::Unassigned(49203)` produced (0xd9 0xc0 0x33).
+    #[test]
+    fn zcash_unified_full_viewing_key_tag_is_unchanged() {
+        let mut packet = vec![];
+        minicbor::encode(sample_accounts(), &mut packet).expect("encoding succeeds");
+        let tag_bytes = [0xd9, 0xc0, 0x33];
+        let count = packet
+            .windows(tag_bytes.len())
+            .filter(|w| *w == tag_bytes)
+            .count();
+        assert_eq!(count, 2, "expected tag 49203 once per account entry");
+    }
+
+    #[test]
+    fn zcash_accounts_ur_fragmentation_is_unchanged() {
+        let mut packet = vec![];
+        minicbor::encode(sample_accounts(), &mut packet).expect("encoding succeeds");
+
+        let mut encoder =
+            ur::Encoder::new(&packet, 100, ZCASH_ACCOUNTS).expect("UR encoder builds");
+        let parts: Vec<String> = (0..EXPECTED_UR_PARTS.len())
+            .map(|_| encoder.next_part().expect("part encodes"))
+            .collect();
+
+        assert_eq!(parts, EXPECTED_UR_PARTS);
+    }
+}


### PR DESCRIPTION
Closes #225. Stacked on #224 (`dep-bumps-local` is the base branch); once that merges this should rebase cleanly onto `main`. The diff shown here is just the two follow-up commits.

### Legacy `ZcashAccounts` fixture (tag 49203)

`keystone enroll`'s `ZcashAccounts` encoding is shared with Keystone hardware wallets but was the one wire format left unpinned after #224's `minicbor` migration from `Tag::Unassigned(49203)` to `Tag::new(49203)`. Three new tests in `src/commands/keystone.rs` now cover it:

- **CBOR bytes** — the full deterministic encoding, including both map shapes (`name` present and absent) and a multi-byte account index.
- **The registry tag itself** — asserts `0xd9 0xc0 0x33` (tag 49203) appears exactly once per account entry, since that's what lets firmware recognise each UFVK.
- **UR fragmentation** — eight consecutive `ur:zcash-accounts/…` parts: all seven payload fragments plus one fountain-combined part, covering the XOR path.

The expected values are genuinely *legacy*: they were captured by compiling this same encoder (verbatim, with `Tag::Unassigned`) against the pre-upgrade `minicbor` 0.19.1 / `ur` 0.4.1 pair, not generated by the new code. The new `minicbor` 2 / `ur` 0.5 code reproduces them byte-for-byte. Verified non-vacuous: corrupting one fixture character fails the test.

### CI now runs the wire-format tests

The fixed-vector tests from #224 and this PR all live behind `pczt-qr`, which no CI job built — so none of this hardware-wallet interoperability coverage was continuously exercised. A new job builds, tests, and clippy-lints with `--features pczt-qr` on ubuntu and macOS (matrix because `nokhwa`'s camera backends are platform-specific native code).

### Verification

- `cargo test --features tui,pczt-qr,qr,regtest_support` — **31 passed, 0 failed** (28 → 31)
- `cargo clippy --all-targets -- -D warnings`, default and with `pczt-qr` — clean
- `cargo fmt --all -- --check` — clean
- The macOS leg of the new CI job mirrors what was run locally; the ubuntu leg (nokhwa's v4l bindings) is proven by this PR's own checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
