### PR TITLE
Migrate to the released librustzcash crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.19",
  "v_frame",
@@ -2251,7 +2251,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -2313,7 +2314,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -4500,8 +4502,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
-source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -4700,6 +4703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4712,8 +4721,9 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5592f4f3eba7f9344cc423f45b6e65911e0630c9b89968d5a20792aadd5a0eb"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -9538,7 +9548,8 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32",
  "bs58",
@@ -9550,8 +9561,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ad58d8ca5daacbc089bf82ec09e45cf2a8be40adeb40b9399b16545c81a528"
 dependencies = [
  "ambassador",
  "arti-client",
@@ -9623,8 +9635,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd92e4334619b1e3f67019254049318ec0d0240a3c15d853bdf2ac4bba597078"
 dependencies = [
  "ambassador",
  "bip32",
@@ -9639,6 +9652,8 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard",
+ "pastey 0.2.3",
+ "pczt",
  "prost",
  "rand 0.8.7",
  "rand_chacha 0.3.1",
@@ -9685,7 +9700,8 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
 dependencies = [
  "bech32",
  "bip32",
@@ -9727,9 +9743,11 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6188c544911aad647bdb0730d18a0309991da1ccbbdab0415d4ef3113ecadcb3"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",
@@ -9747,8 +9765,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403d5be1e96339534be098e3377fb8a78d68ca7585b1780133d884b810277418"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -9779,7 +9798,8 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -9800,8 +9820,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "314329b91ec4bbb517441840e47d0b2029bf0b946f086980c96c889c2d92dc5d"
 dependencies = [
  "corez",
  "document-features",
@@ -9842,7 +9863,8 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -9935,8 +9957,9 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=6c07e5f3297febf469e5cc8d0b91321e0767cdd7#6c07e5f3297febf469e5cc8d0b91321e0767cdd7"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0180028b8807c60498f01eb805a125eed095ab4c4a1737635c80e6ef7cb0a9c"
 dependencies = [
  "base64",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,43 +40,25 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = "1"
 
 # Zcash
-#
-# NOTE: zcash_client_backend/zcash_client_sqlite/pczt/zip321 version reqs
-# below are pinned to the exact prerelease versions on the librustzcash
-# main revision in [patch.crates-io] below — these are ahead of the last
-# crates.io releases. If the patch rev changes,
-# re-check these against the new rev's Cargo.toml files, or Cargo will
-# silently fall back to stale crates.io versions for the unsatisfied ones
-# and duplicate half the dependency graph (as happened here).
 orchard = { version = "0.15.0", default-features = false }
 pczt = { version = "0.9.1", features = ["io-finalizer", "orchard", "prover", "signer", "spend-finalizer", "transparent", "tx-extractor"] }
 sapling = { package = "sapling-crypto", version = "0.7" }
 transparent = { package = "zcash_transparent", version = "0.10.0", features = ["test-dependencies", "transparent-inputs"] }
 zcash_address = "0.13.0"
-zcash_client_backend = { version = "0.24.0-rc.6", features = ["lightwalletd-tonic-tls-webpki-roots", "orchard", "pczt", "tor", "unstable"] }
+zcash_client_backend = { version = "0.24.0", features = ["lightwalletd-tonic-tls-webpki-roots", "orchard", "pczt", "tor", "unstable"] }
 # `transparent-inputs` is enabled unconditionally: `zcash_client_backend`'s `pczt`
 # feature (always on here) already forces `zcash_client_backend/transparent-inputs`,
 # so `zcash_client_sqlite` must match or its `WalletRead`/`WalletWrite` impls fail to
 # cover the trait's transparent methods.
-zcash_client_sqlite = { version = "0.22.0-rc.6", features = ["transparent-inputs", "unstable", "orchard", "serde", "test-dependencies"] }
+zcash_client_sqlite = { version = "0.22.0", features = ["transparent-inputs", "unstable", "orchard", "serde", "test-dependencies"] }
 zcash_keys = { version = "0.16.1", features = ["orchard", "sapling", "unstable", "unstable-frost"] }
+zcash_pool_migration = { version = "0.1", features = ["wallet"] }
 zcash_primitives = "0.30.0"
 zcash_proofs = { version = "0.30.0", features = ["bundled-prover"] }
 zcash_protocol = { version = "0.10.3", features = ["local-consensus"] }
 zcash_script = "0.4"
 zip32 = "0.2"
-zip321 = "0.9.0-rc.1"
-
-# Backend-agnostic value-pool migration engine (Orchard -> Ironwood, NU6.3).
-# Not yet published to crates.io; lives in librustzcash main now that #2663
-# (engine) and #2710 (proving) are both merged. Pinned to the same commit as
-# the [patch.crates-io] block above. `wallet` feature pulls in the
-# `WalletMigration` adapter used to drive the engine over our own WalletDb.
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7", features = ["wallet"] }
-# The standalone zcash_pool_migration_sqlite crate is gone as of this pin: the
-# SQLite store (pool_migrations tables + PoolMigrationRead/Write) moved into
-# zcash_client_sqlite::pool_migration::orchard_ironwood as a hard (non-optional)
-# dependency, so no separate crate/feature is needed for it any more.
+zip321 = "0.9"
 
 # CLI
 clap = { version = "4.5", features = ["derive", "string", "unstable-styles"] }
@@ -145,31 +127,3 @@ tui = [
     "dep:tokio-util",
     "dep:tui-logger",
 ]
-
-[patch.crates-io]
-# Pinned to zcash/librustzcash main as of 2026-07-30. The pool-migration
-# engine (#2663) and its proving support (#2710, "consult the drawn anchor
-# boundary at proving time") are both merged upstream now, so this no longer
-# tracks Danny Willems' feat/pool-migration-sqlite branch -- that branch is
-# superseded, main has everything it had plus the proving primitive
-# (zcash_pool_migration is still not published to crates.io, so it remains
-# pinned by git revision.)
-#
-# orchard is patched here too, mirroring librustzcash's OWN
-# [patch.crates-io] pin (orchard PR #535, deferred-anchor Updater setters)
-# at this same commit -- a git dependency's own nested patches don't
-# propagate to ours, so this workspace needs its own matching entry or the
-# graph disagrees on which orchard it's building against.
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "6c07e5f3297febf469e5cc8d0b91321e0767cdd7" }

--- a/src/commands/migration/advance.rs
+++ b/src/commands/migration/advance.rs
@@ -5,13 +5,25 @@ use uuid::Uuid;
 
 use zcash_client_backend::data_api::{Account as _, WalletRead};
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
-use zcash_pool_migration::engine::{MigrationTxKind, prove_preparation, prove_transfer};
-use zcash_pool_migration::state::AdvanceStep;
+use zcash_pool_migration::engine::{
+    MigrationTxKind, PoolMigrationRead, PoolMigrationWrite, ProveOutcome, prove_preparation,
+    prove_transfer,
+};
+use zcash_pool_migration::satisfiability::{
+    AdvanceConfig, DuenessTargets, ReorgSettleDepth, advance_migration,
+};
+use zcash_pool_migration::state::{AdvanceStep, StepKind};
 use zcash_pool_migration::wallet::WalletMigrationProver;
 
 use crate::{commands::select_account, config::get_wallet_network, data::get_db_paths};
 
-use super::store::{load_migration, open_connection, persist_migration};
+use super::store::{migration_store, open_connection};
+
+/// How far the chain must advance past a divergence before this command treats a displacement as
+/// permanent. Caller policy that `zcash_pool_migration` deliberately ships no default for: the
+/// right value tracks the chain's block spacing, and ten blocks is the same settle margin the
+/// crate's own anchor-depth gate (`PROVABLE_ANCHOR_DEPTH`) uses at the 75-second block target.
+const REORG_SETTLE_DEPTH: ReorgSettleDepth = ReorgSettleDepth::new(10);
 
 /// Options accepted for the `migration advance` command.
 #[derive(Debug, Args)]
@@ -26,78 +38,132 @@ impl Command {
         let (_, db_path) = get_db_paths(wallet_dir.as_ref());
         let mut conn = open_connection(&db_path)?;
 
-        // `PoolMigrations` is account-scoped now, so the account must be resolved before loading
-        // -- in its own scope, since `WalletDb::from_connection` and a direct `&conn` borrow for
-        // `load_migration` can't both be alive at once.
-        let account_id = {
+        // The account's identity, its Orchard viewing key, and the two heights the migration's
+        // dueness is judged against, read through a `WalletDb` view that is dropped before the
+        // migration store borrows the same connection.
+        let (account_id, fvk, scanned, tip) = {
             let wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
-            select_account(&wallet_db, self.account_id)?.id()
+            let account = select_account(&wallet_db, self.account_id)?;
+            let fvk = account
+                .ufvk()
+                .and_then(|ufvk| ufvk.orchard())
+                .cloned()
+                .ok_or_else(|| anyhow!("account has no Orchard viewing key"))?;
+            // The SCANNED frontier is what every persisted verdict and every anchor lookup rests
+            // on: a checkpoint only exists where the wallet has scanned. The chain tip is merely
+            // this wallet's best estimate of where the chain has reached, and only re-orders (or
+            // protectively withholds) work the scanned frontier already justifies.
+            let scanned = wallet_db
+                .block_fully_scanned()
+                .map_err(|e| anyhow!("wallet read failed: {e:?}"))?
+                .ok_or_else(|| anyhow!("wallet has not scanned any blocks yet"))?
+                .block_height();
+            let tip = wallet_db
+                .chain_height()
+                .map_err(|e| anyhow!("wallet read failed: {e:?}"))?
+                .ok_or_else(|| anyhow!("wallet is not synced"))?;
+            (account.id(), fvk, scanned, tip)
+        };
+        // Both heights carry the engine's TARGET convention: the height of the next block a
+        // transaction could be mined in.
+        let targets = DuenessTargets::new(scanned + 1, tip + 1);
+
+        let mut rng = OsRng;
+        let config = AdvanceConfig::new(REORG_SETTLE_DEPTH);
+
+        // `advance_migration` plans the next step, verifies it against the store's satisfiability
+        // oracle, and persists every determination it makes along the way -- so the step it
+        // returns is one this wallet can actually act on.
+        let (advance, mut state) = {
+            let mut store = migration_store(params, &mut conn, account_id)?;
+            let Some(mut state) = store.get_migration()? else {
+                println!("No migration in progress.");
+                return Ok(());
+            };
+            let advance = advance_migration(&mut store, &mut state, targets, &config, &mut rng)?;
+            (advance, state)
         };
 
-        let Some(mut state) = load_migration(&conn, account_id)? else {
-            println!("No migration in progress.");
-            return Ok(());
-        };
+        match advance.step() {
+            AdvanceStep::Prove { transactions } => {
+                // The step names the WHOLE currently provable set: proving emits nothing a
+                // network observer can see, so there is no reason to space it out. Each proof is
+                // taken with the wallet borrowed mutably (witness resolution caches into the
+                // commitment tree) and then persisted through the store, which needs the same
+                // connection -- hence the alternating scopes.
+                for target in transactions {
+                    let id = target.id();
+                    let outcome = {
+                        let mut wallet_db =
+                            WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
+                        let mut prover =
+                            WalletMigrationProver::new(&mut wallet_db, account_id, fvk.clone());
+                        match target.kind() {
+                            MigrationTxKind::Transfer { .. } => prove_transfer(
+                                &params,
+                                &mut prover,
+                                &mut state,
+                                id,
+                                scanned,
+                                &mut rng,
+                            ),
+                            // A preparation carries no drawn anchor boundary of its own (it
+                            // anchors to its already-mined dependencies), so the caller picks the
+                            // checkpoint; the scanned frontier is always valid, since the
+                            // dependencies are confirmed mined at or below it by the time this
+                            // step is offered.
+                            MigrationTxKind::Preparation { .. } => {
+                                prove_preparation(&mut prover, &mut state, id, scanned)
+                            }
+                        }
+                        .map_err(|e| anyhow!("proving transaction {} failed: {e}", u32::from(id)))?
+                    };
 
-        // Every transaction is already built and signed at commit time now (one signing phase),
-        // so there is nothing left for `advance` to build. It proves transactions whose deferred
-        // anchor is ready (installing it and the spend witnesses through the PCZT `Updater` role,
-        // ZIP 374) and orders broadcasts against the LIVE chain tip, same as `migration status`
-        // -- anything derived from the migration's own schedule would make transactions look
-        // ready regardless of the real chain.
-        let mut wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
-        let account = select_account(&wallet_db, self.account_id)?;
-        let fvk = account
-            .ufvk()
-            .and_then(|ufvk| ufvk.orchard())
-            .cloned()
-            .ok_or_else(|| anyhow!("account has no Orchard viewing key"))?;
-        let account_id_for_prover = account.id();
-
-        let tip = wallet_db
-            .chain_height()
-            .map_err(|e| anyhow!("wallet read failed: {e:?}"))?
-            .ok_or_else(|| anyhow!("wallet is not synced"))?;
-        let target_height = tip + 1;
-
-        match state.next_step(target_height) {
-            AdvanceStep::Prove { id } => {
-                let kind = state
-                    .transaction_statuses(target_height)
-                    .into_iter()
-                    .find(|tx| tx.id() == id)
-                    .map(|tx| tx.kind())
-                    .ok_or_else(|| anyhow!("transaction {} not found", u32::from(id)))?;
-
-                let mut prover =
-                    WalletMigrationProver::new(&mut wallet_db, account_id_for_prover, fvk);
-                match kind {
-                    MigrationTxKind::Transfer { .. } => {
-                        prove_transfer(&mut prover, &mut state, id).map_err(|e| {
-                            anyhow!("proving transfer {} failed: {e}", u32::from(id))
-                        })?;
-                    }
-                    // A preparation carries no drawn anchor boundary of its own (it anchors to its
-                    // already-mined dependencies), so the caller picks the checkpoint; the current
-                    // tip is always valid since the dependencies are already confirmed mined by
-                    // the time `next_step` returns `Prove` for it.
-                    MigrationTxKind::Preparation { .. } => {
-                        prove_preparation(&mut prover, &mut state, id, tip).map_err(|e| {
-                            anyhow!("proving preparation {} failed: {e}", u32::from(id))
-                        })?;
+                    let mut store = migration_store(params, &mut conn, account_id)?;
+                    match outcome {
+                        ProveOutcome::Proved(proven) => {
+                            store.store_proved_transaction(&mut state, proven)?;
+                            println!("Proved transaction {}.", u32::from(id));
+                        }
+                        ProveOutcome::NotYetProvable => {
+                            // Nothing was concluded, but a proving-time anchor re-draw may have
+                            // been recorded on the way; persisting it costs one write and saves
+                            // re-deriving it.
+                            store.replace_migration(&state)?;
+                            println!(
+                                "Transaction {} is not provable yet: an input it spends is not \
+                                 among the account's unspent notes, and the wallet has not \
+                                 scanned past every dependency's mined height. Sync further and \
+                                 re-run.",
+                                u32::from(id)
+                            );
+                        }
+                        ProveOutcome::MarkedUnsatisfiable { replan_required } => {
+                            store.replace_migration(&state)?;
+                            println!(
+                                "Transaction {} can never mine: an input it spends was seen spent \
+                                 elsewhere. It is marked unsatisfiable, along with everything \
+                                 stranded behind it.",
+                                u32::from(id)
+                            );
+                            if replan_required {
+                                println!(
+                                    "Enough planned value is now unsatisfiable that the migration \
+                                     must be re-planned; the next `migration advance` will say so."
+                                );
+                            }
+                        }
                     }
                 }
-                persist_migration(&mut conn, account_id, &state)?;
-                println!("Proved transaction {}.", u32::from(id));
             }
             AdvanceStep::Broadcast { id } => {
                 println!(
-                    "Transaction {} is proved and ready to broadcast, but broadcasting isn't \
-                     wired up in this command yet: it needs a lightwalletd client and extracting \
-                     the finalized transaction from the proven PCZT, neither of which any \
-                     `migration` command builds yet. Re-run `migration advance` once that lands, \
-                     or `migration status` to check state anytime.",
-                    u32::from(id)
+                    "Transaction {} is proved and due to broadcast, but broadcasting isn't wired \
+                     up in this command yet: it needs a lightwalletd client alongside \
+                     `PoolMigrations::take_transaction_for_broadcast`, which extracts the \
+                     finalized transaction and records it wallet-side. Re-run `migration advance` \
+                     once that lands, or `migration status` to check state anytime.",
+                    u32::from(*id)
                 );
             }
             AdvanceStep::Rebuild { id } => {
@@ -105,7 +171,21 @@ impl Command {
                     "Transfer {} expired before mining and needs to be rebuilt with a fresh \
                      anchor and signed anew -- not implemented in this command yet (rebuilding \
                      needs the account's spend authority, the same as `migration commit`).",
-                    u32::from(id)
+                    u32::from(*id)
+                );
+            }
+            AdvanceStep::Replan => {
+                println!(
+                    "Too much of this migration's planned value can never mine, so it must be \
+                     re-planned: mark it superseded and plan a new migration over the remaining \
+                     balance. Superseding isn't wired up in this command yet."
+                );
+            }
+            AdvanceStep::Reevaluate => {
+                println!(
+                    "A node rejected a broadcast of one of this migration's transactions, and \
+                     this wallet hasn't scanned far enough to say why. Sync to at least the tip \
+                     that node reported, then re-run `migration advance`."
                 );
             }
             AdvanceStep::Waiting => {
@@ -114,6 +194,22 @@ impl Command {
             AdvanceStep::Complete => {
                 println!("Migration complete.");
             }
+        }
+
+        // The outlook: what the migration holds once the step above is executed. Advisory -- the
+        // height is a floor, and the `migration advance` run that reaches it decides (and may
+        // displace) the step for itself.
+        if let Some((height, kind)) = advance.next() {
+            let what = match kind {
+                StepKind::Prove => "proving",
+                StepKind::Broadcast => "a broadcast",
+                StepKind::Rebuild => "an expired transfer's rebuild",
+                StepKind::Replan => "a re-plan",
+                StepKind::Reevaluate => "a re-evaluation after syncing",
+                StepKind::Waiting => "more waiting",
+                StepKind::Complete => "nothing further",
+            };
+            println!("Outlook: {what}, from target height {height}.");
         }
 
         Ok(())

--- a/src/commands/migration/commit.rs
+++ b/src/commands/migration/commit.rs
@@ -25,15 +25,29 @@ pub(crate) struct Command {
     /// The UUID of the account to commit a migration for
     account_id: Option<Uuid>,
 
-    /// age identity file to decrypt the mnemonic phrase with
-    #[arg(short, long)]
-    identity: String,
+    /// age identity file to decrypt the mnemonic phrase with. Not required with `--external`:
+    /// building a migration for an external signer is a viewing-key operation, so no spending
+    /// key is derived for it.
+    #[arg(short, long, required_unless_present = "external")]
+    identity: Option<String>,
 
     /// Build the migration for an EXTERNAL signer (e.g. Keystone) instead of signing
     /// in-process: leaves every transaction unsigned in the persisted state, and additionally
     /// writes each one to `<wallet-dir>/unsigned-pczts/<id>.pczt` for `pczt to-qr-batch`.
     #[arg(long)]
     external: bool,
+}
+
+/// Where this run's spend authority comes from. Everything a migration does short of signing is
+/// a viewing-key operation, so the spending key exists only on the path that actually signs --
+/// and this makes "external signing, but a spending key was derived anyway" unrepresentable.
+enum Signing {
+    /// Sign in-process with the account's own spend authority, live for the commit call alone.
+    /// Boxed: a `UnifiedSpendingKey` is several hundred bytes, and the external variant carries
+    /// none.
+    InProcess(Box<UnifiedSpendingKey>),
+    /// Leave every transaction unsigned, for a hardware or offline signer.
+    External,
 }
 
 impl Command {
@@ -49,11 +63,9 @@ impl Command {
         let (account_id, ufvk, account_index) = {
             let wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
             let account = select_account(&wallet_db, self.account_id)?;
-            let account_index = account
-                .source()
-                .key_derivation()
-                .ok_or_else(|| anyhow!("Cannot commit a migration for a view-only account"))?
-                .account_index();
+            // Only the in-process signing path needs a derivation path; an account whose spend
+            // authority lives on a device may legitimately have none.
+            let account_index = account.source().key_derivation().map(|d| d.account_index());
             // The key the account's notes were received with: the engine derives the Orchard
             // full viewing key it plans, builds and stores against from this, and checks the
             // spend authority passed to `commit_preparation` against it.
@@ -64,12 +76,24 @@ impl Command {
         };
         let loaded = load_migration(params, &conn, account_id)?;
 
-        let identities = age::IdentityFile::from_file(self.identity)?.into_identities()?;
-        let seed = config
-            .decrypt_seed(identities.iter().map(|i| i.as_ref() as _))?
-            .ok_or_else(|| anyhow!("Seed must be present to commit a migration"))?;
-        let usk = UnifiedSpendingKey::from_seed(&params, seed.expose_secret(), account_index)
-            .map_err(|e| anyhow!("{e:?}"))?;
+        let signing = if self.external {
+            Signing::External
+        } else {
+            let identity = self.identity.as_ref().ok_or_else(|| {
+                anyhow!("An age identity is required to sign a migration in-process")
+            })?;
+            let account_index = account_index.ok_or_else(|| {
+                anyhow!("Cannot sign a migration in-process for an account with no key derivation")
+            })?;
+            let identities = age::IdentityFile::from_file(identity.clone())?.into_identities()?;
+            let seed = config
+                .decrypt_seed(identities.iter().map(|i| i.as_ref() as _))?
+                .ok_or_else(|| anyhow!("Seed must be present to sign a migration in-process"))?;
+            Signing::InProcess(Box::new(
+                UnifiedSpendingKey::from_seed(&params, seed.expose_secret(), account_index)
+                    .map_err(|e| anyhow!("{e:?}"))?,
+            ))
+        };
 
         let map_commit_err = |e: CommitError<_>| match e {
             CommitError::MigrationInProgress => anyhow!(
@@ -121,8 +145,8 @@ impl Command {
                 plan.preparation().transaction_count(),
             );
 
-            if self.external {
-                build_preparation_unsigned(
+            match &signing {
+                Signing::External => build_preparation_unsigned(
                     &params,
                     target_height,
                     &mut migration,
@@ -130,22 +154,23 @@ impl Command {
                     &mut rng,
                     ReplanThreshold::DEFAULT,
                 )
-                .map_err(map_commit_err)?
-            } else {
+                .map_err(map_commit_err)?,
                 // The spend authority is the CALL's, not the adapter's: `WalletMigration` holds
                 // only viewing authority, and the Orchard spending key is live just for this
                 // call (checked against the account's viewing key before anything is built).
-                let state = commit_preparation(
-                    &params,
-                    target_height,
-                    &mut migration,
-                    usk.orchard(),
-                    &plan,
-                    &mut rng,
-                    ReplanThreshold::DEFAULT,
-                )
-                .map_err(map_commit_err)?;
-                (state, Vec::new())
+                Signing::InProcess(usk) => {
+                    let state = commit_preparation(
+                        &params,
+                        target_height,
+                        &mut migration,
+                        usk.orchard(),
+                        &plan,
+                        &mut rng,
+                        ReplanThreshold::DEFAULT,
+                    )
+                    .map_err(map_commit_err)?;
+                    (state, Vec::new())
+                }
             }
         };
 

--- a/src/commands/migration/commit.rs
+++ b/src/commands/migration/commit.rs
@@ -12,6 +12,7 @@ use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_pool_migration::engine::{
     CommitError, build_preparation_unsigned, commit_preparation, plan_migration,
 };
+use zcash_pool_migration::satisfiability::ReplanThreshold;
 use zcash_pool_migration::wallet::WalletMigration;
 
 use crate::{commands::select_account, config::WalletConfig, data::get_db_paths};
@@ -42,50 +43,33 @@ impl Command {
         let (_, db_path) = get_db_paths(wallet_dir.as_ref());
         let mut conn = open_connection(&db_path)?;
 
-        // `PoolMigrations` is account-scoped now, so the account must be resolved before loading
-        // -- in its own scope, since `WalletDb::from_connection` and a direct `&conn` borrow for
-        // `load_migration` can't both be alive at once.
-        let account_id = {
+        // The account's identity, viewing key, and derivation path, read through a `WalletDb`
+        // view that is dropped before the migration store borrows the same connection.
+        // `PoolMigrations` is account-scoped, so the account must be resolved before loading.
+        let (account_id, ufvk, account_index) = {
             let wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
-            select_account(&wallet_db, self.account_id)?.id()
+            let account = select_account(&wallet_db, self.account_id)?;
+            let account_index = account
+                .source()
+                .key_derivation()
+                .ok_or_else(|| anyhow!("Cannot commit a migration for a view-only account"))?
+                .account_index();
+            // The key the account's notes were received with: the engine derives the Orchard
+            // full viewing key it plans, builds and stores against from this, and checks the
+            // spend authority passed to `commit_preparation` against it.
+            let ufvk = account.ufvk().cloned().ok_or_else(|| {
+                anyhow!("Cannot commit a migration for an account with no unified full viewing key")
+            })?;
+            (account.id(), ufvk, account_index)
         };
-        let loaded = load_migration(&conn, account_id)?;
+        let loaded = load_migration(params, &conn, account_id)?;
 
         let identities = age::IdentityFile::from_file(self.identity)?.into_identities()?;
         let seed = config
             .decrypt_seed(identities.iter().map(|i| i.as_ref() as _))?
             .ok_or_else(|| anyhow!("Seed must be present to commit a migration"))?;
-
-        let wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
-        let account = select_account(&wallet_db, self.account_id)?;
-        let derivation = account
-            .source()
-            .key_derivation()
-            .ok_or_else(|| anyhow!("Cannot commit a migration for a view-only account"))?;
-        let usk = UnifiedSpendingKey::from_seed(
-            &params,
-            seed.expose_secret(),
-            derivation.account_index(),
-        )
-        .map_err(|e| anyhow!("{e:?}"))?;
-
-        let target_height = wallet_db
-            .chain_height()
-            .map_err(|e| anyhow!("wallet read failed: {e:?}"))?
-            .ok_or_else(|| anyhow!("wallet is not synced"))?;
-        let target_height = target_height + 1;
-
-        let mut migration =
-            WalletMigration::new(&wallet_db, account.id(), usk, InMemoryStore::from(loaded));
-        let mut rng = OsRng;
-        let plan = plan_migration(&params, &migration, &mut rng).map_err(|e| anyhow!("{e}"))?;
-
-        println!(
-            "Committing migration: {} funding note(s), {} preparation layer(s), {} preparation transaction(s)",
-            plan.funding_notes().len(),
-            plan.preparation().layer_count(),
-            plan.preparation().transaction_count(),
-        );
+        let usk = UnifiedSpendingKey::from_seed(&params, seed.expose_secret(), account_index)
+            .map_err(|e| anyhow!("{e:?}"))?;
 
         let map_commit_err = |e: CommitError<_>| match e {
             CommitError::MigrationInProgress => anyhow!(
@@ -116,13 +100,53 @@ impl Command {
             None
         };
 
-        let (state, unsigned) = if self.external {
-            build_preparation_unsigned(&params, target_height, &mut migration, &plan, &mut rng)
+        let mut rng = OsRng;
+        let (state, unsigned) = {
+            let wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
+
+            let target_height = wallet_db
+                .chain_height()
+                .map_err(|e| anyhow!("wallet read failed: {e:?}"))?
+                .ok_or_else(|| anyhow!("wallet is not synced"))?
+                + 1;
+
+            let mut migration =
+                WalletMigration::new(&wallet_db, account_id, ufvk, InMemoryStore::from(loaded));
+            let plan = plan_migration(&params, &migration, &mut rng).map_err(|e| anyhow!("{e}"))?;
+
+            println!(
+                "Committing migration: {} funding note(s), {} preparation layer(s), {} preparation transaction(s)",
+                plan.funding_notes().len(),
+                plan.preparation().layer_count(),
+                plan.preparation().transaction_count(),
+            );
+
+            if self.external {
+                build_preparation_unsigned(
+                    &params,
+                    target_height,
+                    &mut migration,
+                    &plan,
+                    &mut rng,
+                    ReplanThreshold::DEFAULT,
+                )
                 .map_err(map_commit_err)?
-        } else {
-            let state = commit_preparation(&params, target_height, &mut migration, &plan, &mut rng)
+            } else {
+                // The spend authority is the CALL's, not the adapter's: `WalletMigration` holds
+                // only viewing authority, and the Orchard spending key is live just for this
+                // call (checked against the account's viewing key before anything is built).
+                let state = commit_preparation(
+                    &params,
+                    target_height,
+                    &mut migration,
+                    usk.orchard(),
+                    &plan,
+                    &mut rng,
+                    ReplanThreshold::DEFAULT,
+                )
                 .map_err(map_commit_err)?;
-            (state, Vec::new())
+                (state, Vec::new())
+            }
         };
 
         if let Some(out_dir) = &external_out_dir {
@@ -157,7 +181,7 @@ impl Command {
             );
         }
 
-        persist_migration(&mut conn, account.id(), &state)?;
+        persist_migration(params, &mut conn, account_id, &state)?;
 
         println!(
             "Migration committed: status={}, {} transaction(s) recorded",

--- a/src/commands/migration/status.rs
+++ b/src/commands/migration/status.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 use zcash_client_backend::data_api::{Account as _, WalletRead};
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
 use zcash_pool_migration::engine::{MigrationTxKind, MigrationTxState};
-use zcash_pool_migration::state::{AdvanceStep, Blocker};
+use zcash_pool_migration::satisfiability::DuenessTargets;
+use zcash_pool_migration::state::{Blocker, NextAction};
 
 use crate::{commands::select_account, config::get_wallet_network, data::get_db_paths};
 
@@ -25,32 +26,43 @@ impl Command {
         let (_, db_path) = get_db_paths(wallet_dir.as_ref());
         let mut conn = open_connection(&db_path)?;
 
-        // `PoolMigrations` is account-scoped now, so the account must be resolved before loading
-        // -- in its own scope, since `WalletDb::from_connection` and a direct `&conn` borrow for
-        // `load_migration` can't both be alive at once.
-        let account_id = {
+        // `PoolMigrations` is account-scoped, so the account must be resolved before loading --
+        // in its own scope, since `WalletDb::from_connection` and the store's borrow of the same
+        // connection can't both be alive at once.
+        //
+        // The two heights must come from the wallet, not from anything derived from the
+        // migration's own schedule: dueness is judged against them, so a synthetic stand-in (the
+        // schedule's own maximum, say) would make transactions look ready regardless of the real
+        // chain. Matches `migration advance`.
+        let (account_id, scanned, tip) = {
             let wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
-            select_account(&wallet_db, self.account_id)?.id()
+            let account = select_account(&wallet_db, self.account_id)?;
+            let scanned = wallet_db
+                .block_fully_scanned()
+                .map_err(|e| anyhow!("wallet read failed: {e:?}"))?
+                .ok_or_else(|| anyhow!("wallet has not scanned any blocks yet"))?
+                .block_height();
+            let tip = wallet_db
+                .chain_height()
+                .map_err(|e| anyhow!("wallet read failed: {e:?}"))?
+                .ok_or_else(|| anyhow!("wallet is not synced"))?;
+            (account.id(), scanned, tip)
         };
+        let targets = DuenessTargets::new(scanned + 1, tip + 1);
 
-        let Some(state) = load_migration(&conn, account_id)? else {
+        let Some(state) = load_migration(params, &conn, account_id)? else {
             println!("No migration in progress.");
             return Ok(());
         };
 
         println!("Status: {}", state.status().as_ref());
-        // Must be the LIVE chain tip, not a synthetic stand-in: next_step()/transaction_statuses()
-        // treat anything with scheduled_height <= target_height as due, so a synthetic height
-        // derived from the migration's OWN schedule (e.g. its max) would make transactions look
-        // ready regardless of the real chain -- the opposite of "safe". Matches migration advance.
-        let wallet_db = WalletDb::from_connection(&mut conn, params, SystemClock, OsRng);
-        let tip = wallet_db
-            .chain_height()
-            .map_err(|e| anyhow!("wallet read failed: {e:?}"))?
-            .ok_or_else(|| anyhow!("wallet is not synced"))?;
-        let target_height = tip + 1;
+        println!(
+            "Judged at scanned target {}, estimated target {}",
+            targets.scanned(),
+            targets.effective()
+        );
 
-        let statuses = state.transaction_statuses(target_height);
+        let statuses = state.transaction_statuses(targets);
         println!("Transactions ({}):", statuses.len());
         for tx in &statuses {
             let kind = match tx.kind() {
@@ -66,44 +78,84 @@ impl Command {
                 MigrationTxState::Broadcast { txid } => {
                     format!("broadcast (txid {})", hex::encode(*txid.as_ref()))
                 }
-                MigrationTxState::Mined { height } => format!("mined at {height}"),
+                MigrationTxState::Mined { txid, height } => {
+                    format!("mined at {height} (txid {})", hex::encode(*txid.as_ref()))
+                }
             };
             let blocker = match tx.blocked_on() {
-                Some(Blocker::Dependencies) => " [blocked: dependencies]",
-                Some(Blocker::Schedule) => " [blocked: schedule]",
-                Some(Blocker::AnchorBoundary) => " [blocked: anchor boundary not yet settled]",
-                Some(Blocker::Signature) => " [blocked: awaiting external signature]",
-                Some(Blocker::Expired) => " [blocked: expired, needs rebuild]",
-                None => "",
+                Some(Blocker::Dependencies) => " [blocked: dependencies]".to_string(),
+                Some(Blocker::Schedule) => " [blocked: schedule]".to_string(),
+                Some(Blocker::AnchorBoundary) => {
+                    " [blocked: anchor boundary not yet settled]".to_string()
+                }
+                Some(Blocker::Signature) => " [blocked: awaiting external signature]".to_string(),
+                Some(Blocker::ExpiryImminent) => {
+                    " [blocked: expiry probably passed, withheld pending scan]".to_string()
+                }
+                Some(Blocker::Expired) => " [blocked: expired, needs rebuild]".to_string(),
+                Some(Blocker::AwaitingReevaluation) => {
+                    " [blocked: a node rejected its broadcast; sync and re-drive]".to_string()
+                }
+                Some(Blocker::Unsatisfiable) => {
+                    // `UnsatisfiableKind` is `#[non_exhaustive]`; its stable wire name is what
+                    // there is to render, and a future release may add one this build cannot
+                    // name.
+                    let kind = tx
+                        .unsatisfiable_kind()
+                        .map(|k| k.as_ref().to_owned())
+                        .unwrap_or_else(|| "unknown".to_owned());
+                    format!(" [blocked: can never mine ({kind})]")
+                }
+                None => match tx.action() {
+                    Some(NextAction::Prove) if tx.ready() => " [ready: prove]".to_string(),
+                    Some(NextAction::Broadcast) if tx.ready() => " [ready: broadcast]".to_string(),
+                    _ => String::new(),
+                },
             };
             println!(
-                "  [{}] {kind}: {state_str}, scheduled >= {}{blocker}",
+                "  [{}] {kind}: {state_str}, scheduled >= {}, expires after {}{blocker}",
                 u32::from(tx.id()),
                 tx.scheduled_height(),
+                tx.expiry_height(),
             );
         }
 
-        match state.next_step(target_height) {
-            AdvanceStep::Prove { id } => {
-                println!(
-                    "Next: prove transaction {} (`migration advance`)",
-                    u32::from(id)
-                )
-            }
-            AdvanceStep::Broadcast { id } => {
-                println!(
-                    "Next: broadcast transaction {} (`migration advance`)",
-                    u32::from(id)
-                )
-            }
-            AdvanceStep::Rebuild { id } => {
-                println!(
-                    "Next: rebuild expired transfer {} (`migration advance`)",
-                    u32::from(id)
-                )
-            }
-            AdvanceStep::Waiting => println!("Next: waiting on dependencies or a scheduled height"),
-            AdvanceStep::Complete => println!("Migration complete."),
+        // A read-only summary. The authoritative decision of what to do next is made by
+        // `advance_migration` (which `migration advance` drives): it puts each candidate to the
+        // wallet's satisfiability oracle and records what it finds, so it writes and this does
+        // not. What is reported here is the state machine's own view, unverified.
+        if state.is_terminal() {
+            println!("Next: nothing -- the migration has reached a terminal status.");
+        } else if state.replan_required() {
+            println!(
+                "Next: re-plan -- too much of the planned value can never mine (`migration \
+                 advance` will say so)."
+            );
+        } else if let Some(tx) = statuses.iter().find(|tx| tx.ready()) {
+            let action = match tx.action() {
+                Some(NextAction::Prove) => "prove",
+                Some(NextAction::Broadcast) => "broadcast",
+                None => "act on",
+            };
+            println!(
+                "Next: {action} transaction {} (`migration advance`)",
+                u32::from(tx.id())
+            );
+        } else {
+            println!("Next: waiting on dependencies, an anchor boundary, or a scheduled height");
+        }
+
+        let expired = state.expired_transactions(targets);
+        if !expired.is_empty() {
+            println!(
+                "Expired without mining ({}): {}",
+                expired.len(),
+                expired
+                    .iter()
+                    .map(|id| u32::from(*id).to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
         }
 
         Ok(())

--- a/src/commands/migration/store.rs
+++ b/src/commands/migration/store.rs
@@ -1,13 +1,44 @@
-use std::convert::Infallible;
+use std::fmt;
 use std::path::Path;
 
 use rusqlite::Connection;
 
 use zcash_client_sqlite::AccountUuid;
 use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
+use zcash_client_sqlite::util::SystemClock;
 use zcash_pool_migration::engine::{
-    MigrationState, MigrationTransferId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+    MigrationState, MigrationTransaction, MigrationTransferId, MigrationTxState, PoolMigrationRead,
+    PoolMigrationWrite, ProvedTransaction,
 };
+use zcash_pool_migration::satisfiability::{ReorgSettleDepth, StepSatisfiability};
+use zcash_protocol::TxId;
+use zcash_protocol::consensus::{BlockHeight, Parameters};
+
+/// Why the commit-path scratch store could not answer.
+#[derive(Debug)]
+pub(crate) enum ScratchStoreError {
+    /// A satisfiability question was put to the scratch store. The oracle
+    /// [`PoolMigrationRead::check_step_satisfiability`] answers is the wallet's live view of
+    /// whether a pre-signed transaction's inputs still exist unspent, which only the real SQLite
+    /// store (with the wallet's notes and scan frontier) can supply; a scratch mirror holding
+    /// nothing but a `MigrationState` has no evidence to answer from. Only the drive API
+    /// (`advance_migration`, and the `migration advance` command that calls it) asks this, and it
+    /// runs against the real store.
+    NoChainView,
+}
+
+impl fmt::Display for ScratchStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScratchStoreError::NoChainView => f.write_str(
+                "the commit-path scratch migration store holds no chain view, so it cannot judge \
+                 whether a transaction's inputs are still spendable",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ScratchStoreError {}
 
 /// A throwaway in-memory `PoolMigrationRead`/`Write`, used only for the duration of one engine
 /// call. `WalletDb::from_connection` (for the engine's wallet access) and `PoolMigrations` (the
@@ -17,6 +48,11 @@ use zcash_pool_migration::engine::{
 /// `MigrationInProgress` guard reads through this store too, so it must be SEEDED with whatever
 /// is actually persisted, not left empty, or a genuinely in-progress migration would silently be
 /// overwritten. Mirrors zallet's `InMemoryStore` (zcash/zallet#623, `zallet_core::migrate`).
+///
+/// This is the COMMIT path's store only. Committing asks a store to report the migration in
+/// progress and to persist the one it builds, and nothing else; the drive path, which does need a
+/// chain view (to prove, to sweep in-flight transactions, and to put candidates to the
+/// satisfiability oracle), uses [`migration_store`] instead.
 #[derive(Default)]
 pub(crate) struct InMemoryStore {
     state: Option<MigrationState>,
@@ -29,10 +65,26 @@ impl From<Option<MigrationState>> for InMemoryStore {
 }
 
 impl PoolMigrationRead for InMemoryStore {
-    type Error = Infallible;
+    type Error = ScratchStoreError;
 
     fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
         Ok(self.state.clone())
+    }
+
+    fn check_step_satisfiability(
+        &self,
+        _tx: &MigrationTransaction,
+        _settle: ReorgSettleDepth,
+    ) -> Result<StepSatisfiability, Self::Error> {
+        Err(ScratchStoreError::NoChainView)
+    }
+
+    fn mined_height(&self, _txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
+        // Inclusion is what a wallet's scan discovers, and this store has none. The
+        // `WalletMigration` adapter answers this from the wallet rather than delegating to its
+        // store, so nothing reaches here on the commit path; a caller that did ask gets the same
+        // honest refusal as the satisfiability oracle rather than a fabricated "not mined".
+        Err(ScratchStoreError::NoChainView)
     }
 }
 
@@ -55,6 +107,17 @@ impl PoolMigrationWrite for InMemoryStore {
         // of one engine call, so there is nothing to do here.
         Ok(())
     }
+
+    fn store_proved_transaction(
+        &mut self,
+        state: &mut MigrationState,
+        proven: ProvedTransaction,
+    ) -> Result<(), Self::Error> {
+        // The contract's whole content for a store with no wallet tables of its own: record the
+        // proof on the state, then persist that state.
+        proven.apply(state);
+        self.replace_migration(state)
+    }
 }
 
 /// Opens the wallet's SQLite connection directly (not via `WalletDb::for_path`), so migration
@@ -70,24 +133,46 @@ pub(crate) fn open_connection(db_path: &Path) -> anyhow::Result<Connection> {
     Ok(conn)
 }
 
+/// The real SQLite pool-migration store over `conn`, scoped to `account`.
+///
+/// `PoolMigrations` is account-scoped (it resolves `account` to its `accounts` row up front), so
+/// the caller must know the account before it can reach a migration. The network parameters and
+/// clock are what the store's wallet-side records need, and are required for any WRITE through
+/// it; the returned store borrows `conn` mutably, so a `WalletDb` over the same connection must
+/// be dropped first and re-created afterwards.
+pub(crate) fn migration_store<P: Parameters>(
+    params: P,
+    conn: &mut Connection,
+    account: AccountUuid,
+) -> anyhow::Result<PoolMigrations<&mut Connection, P, SystemClock>> {
+    Ok(PoolMigrations::for_account(
+        params,
+        SystemClock,
+        conn,
+        account,
+    )?)
+}
+
 /// Loads the persisted migration from the real SQLite store over `conn`, scoped to `account`.
-/// `PoolMigrations` is now account-scoped (it resolves `account` to its `accounts` row up front),
-/// so the caller must know the account before it can load a migration -- unlike before this pin,
-/// when the store had no notion of which account it belonged to.
-pub(crate) fn load_migration(
+///
+/// A shared borrow: reading a migration writes nothing, so a caller that only reports on one
+/// never has to hand the store write access.
+pub(crate) fn load_migration<P: Parameters>(
+    params: P,
     conn: &Connection,
     account: AccountUuid,
 ) -> anyhow::Result<Option<MigrationState>> {
-    Ok(PoolMigrations::for_account(conn, account)?.get_migration()?)
+    Ok(PoolMigrations::for_account(params, SystemClock, conn, account)?.get_migration()?)
 }
 
 /// Persists a migration to the real SQLite store over `conn`, scoped to `account`, replacing any
 /// existing one.
-pub(crate) fn persist_migration(
+pub(crate) fn persist_migration<P: Parameters>(
+    params: P,
     conn: &mut Connection,
     account: AccountUuid,
     state: &MigrationState,
 ) -> anyhow::Result<()> {
-    PoolMigrations::for_account(&mut *conn, account)?.replace_migration(state)?;
+    migration_store(params, conn, account)?.replace_migration(state)?;
     Ok(())
 }


### PR DESCRIPTION
The pool-migration engine (`zcash_pool_migration`), its SQLite store, and the wallet crates they sit on are all published now, so the git pins and the `[patch.crates-io]` block that kept the dependency graph consistent with them can go. `zip321`'s requirement was still `0.9.0-rc.1`.

All the API breakage was confined to `src/commands/migration/`.

## What the releases settled on, and how the commands adapt

- **The store traits grew.** `PoolMigrationRead` gained `check_step_satisfiability` and `mined_height`; `PoolMigrationWrite` gained `store_proved_transaction`. The commit path's scratch `InMemoryStore` can honour the last (`proven.apply(state)`, then persist) but holds no chain view to answer the first two from, so its error type is now an ADT that says exactly that rather than `Infallible`.

- **`MigrationState::next_step` is private.** `satisfiability::advance_migration` is the drive API: it puts each candidate to the store's satisfiability oracle, records what it finds, and persists before returning a step. `migration advance` is rewritten around it, driving the real SQLite store rather than the scratch mirror — which by construction cannot answer the oracle.

- **`AdvanceStep::Prove` names the whole provable batch** (`Vec<ProveTarget>`) rather than one transaction, since proving emits nothing a network observer can see. The command loops over it, alternating a `WalletDb` scope (witness resolution caches into the commitment tree, so it needs `&mut`) with a store scope. The prove functions return a `ProveOutcome`, so all three outcomes are handled and the `ProvedTransaction` is discharged through `store_proved_transaction`. Two further steps, `Replan` and `Reevaluate`, are reported.

- **Dueness is judged against a `DuenessTargets` pair** — the wallet's scanned frontier and its estimate of the chain tip — rather than a single height. Since deciding the next step now writes, `migration status` reports read-only from `transaction_statuses` instead, and handles the three new `Blocker` variants and `MigrationTxState::Mined { txid, height }`.

- **`WalletMigration` holds viewing authority alone.** The Orchard spending key is an argument to the calls that sign, and `commit_preparation` / `build_preparation_unsigned` also take a `ReplanThreshold`.

## Two changes beyond mechanical adaptation

**Proving anchors at the fully-scanned height, not `chain_height()`.** The old code passed the chain tip, which can sit above the scanned frontier — where the commitment tree holds no checkpoint to prove against.

**`migration commit --external` no longer derives a spending key.** That flag exists precisely because the account's spend authority is on a device; the old API forced a `UnifiedSpendingKey` through `WalletMigration::new`, and the released one doesn't. The seed is now decrypted only on the path that signs, and `--identity` becomes `required_unless_present = "external"`. This is a small CLI contract change: `--identity` is still required without the flag, and passing it alongside `--external` is still accepted. It also lets the external path serve the accounts it is for — a wallet whose config holds no seed, or an account with no key derivation, previously failed before reaching the builder. The choice is modelled as an enum rather than an `Option<UnifiedSpendingKey>` beside a `bool`, so "external signing, but a spending key was derived anyway" cannot be constructed.

## Verification

`cargo check --all-targets --all-features`, `cargo clippy --all-features --all-targets -- -D warnings`, and `cargo fmt --all -- --check` all exit 0; `cargo test --all-features` gives 32 passed, 0 failed. `cargo check --all-targets` also passes for the default feature set and for each of `regtest_support`, `tui`, `qr`, `pczt-qr`, and all four together. Each of the two commits was verified to build on its own via `git rebase --exec`.

---

Prepared with Claude Code assistance.
