### PR TITLE
List unspent Ironwood notes

### DIFF
--- a/src/commands/wallet/list_unspent.rs
+++ b/src/commands/wallet/list_unspent.rs
@@ -61,6 +61,14 @@ impl Command {
             );
         }
 
+        for note in notes.ironwood() {
+            println!(
+                "Ironwood {}: {}",
+                note.internal_note_id(),
+                format_zec(note.note_value()?, net)
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
`list-unspent` asks `select_unspent_notes` for `ShieldedPool::{Sapling, Orchard, Ironwood}`, but only ever prints the first two — so an account's Ironwood notes are selected and then silently dropped.

Post-NU6.3 that is the pool a ZIP 318 migration moves value *into*, which makes the omission worst exactly where the command is most useful: a wallet that has migrated shows its crossed value nowhere in `list-unspent`, and the output gives no sign that anything is missing.

The fix is the loop that should already have been there, matching the two above it:

```rust
for note in notes.ironwood() {
    println!(
        "Ironwood {}: {}",
        note.internal_note_id(),
        format_zec(note.note_value()?, net)
    );
}
```

`SpendableNotes::ironwood` is gated on `zcash_client_backend/orchard`, which this crate enables unconditionally, so it needs no `#[cfg]` — same as the existing `orchard()` call.

## Verification

`cargo clippy --all-features --all-targets -- -D warnings` and `cargo fmt --all -- --check` both exit 0; `cargo test --all-features` gives 32 passed, 0 failed. `cargo check --all-targets` passes for the default feature set, for `--no-default-features`, and for each of `regtest_support`, `tui`, `qr`, and `pczt-qr`.

---

Prepared with Claude Code assistance.
